### PR TITLE
BI-7459 Implement compare disqualified directors route

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/disqualification/DisqualifiedOfficerCompareTrigger.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/disqualification/DisqualifiedOfficerCompareTrigger.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.reconciliation.disqualification;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mongodb.MongoDbConstants;
+import org.springframework.stereotype.Component;
+
+/**
+ * Trigger a comparison between disqualified officers on Oracle with disqualifications on MongoDB.
+ */
+@Component
+public class DisqualifiedOfficerCompareTrigger extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("{{endpoint.dsq_officer_collection.cron.tab}}")
+                .setBody(constant("{{query.oracle.dsq_officer_collection}}"))
+                .setHeader("Src", simple("{{endpoint.oracle.dsq_officer_collection}}"))
+                .setHeader("SrcName", simple("Oracle"))
+                .setHeader("Target", simple("{{endpoint.mongodb.disqualifications_collection}}"))
+                .setHeader("TargetName", simple("MongoDB"))
+                .setHeader("Destination", simple("{{endpoint.output}}"))
+                .setHeader(MongoDbConstants.DISTINCT_QUERY_FIELD, constant("officer_id_raw"))
+                .to("{{function.name.compare_collection}}");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRoute.java
@@ -39,7 +39,7 @@ public class CompareCollectionRoute extends RouteBuilder {
                     List<String> targetClean = targetBody.stream()
                             .map(obj -> {
                                 Map<?, ?> entry = (Map<?, ?>) obj;
-                                return (String) entry.get("RESULT");
+                                return entry.get("RESULT").toString();
                             })
                             .collect(Collectors.toList());
                     base.getIn().setHeader("SrcList", new ResourceList(targetClean, base.getIn().getHeader("SrcName", String.class)));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,4 +16,9 @@ endpoint.oracle.corporate_body_collection=${ENDPOINT_ORACLE_CORPORATE_BODY_COLLE
 query.oracle.corporate_body_collection=${QUERY_ORACLE_CORPORATE_BODY_COLLECTION}
 endpoint.mongodb.company_profile_collection=${ENDPOINT_MONGODB_COMPANY_PROFILE_COLLECTION}
 
+endpoint.dsq_officer_collection.cron.tab=${ENDPOINT_DSQ_OFFICER_COLLECTION_CRON_TAB}
+endpoint.oracle.dsq_officer_collection=${ENDPOINT_ORACLE_DSQ_OFFICER_COLLECTION}
+query.oracle.dsq_officer_collection=${QUERY_ORACLE_DSQ_OFFICER_COLLECTION}
+endpoint.mongodb.disqualifications_collection=${ENDPOINT_MONGODB_DISQUALIFICATIONS_COLLECTION}
+
 endpoint.output=${ENDPOINT_OUTPUT}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/disqualification/DisqualifiedOfficerCompareTriggerTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/disqualification/DisqualifiedOfficerCompareTriggerTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.reconciliation.disqualification;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.mongodb.MongoDbConstants;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@CamelSpringBootTest
+@SpringBootTest
+@DirtiesContext
+@TestPropertySource(locations = "classpath:application-stubbed.properties")
+public class DisqualifiedOfficerCompareTriggerTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @EndpointInject("mock:compare_collection")
+    private MockEndpoint compareCollection;
+
+    @Produce("direct:dsq_officer_trigger")
+    private ProducerTemplate producerTemplate;
+
+    @BeforeEach
+    void before(){
+        compareCollection.reset();
+    }
+
+    @Test
+    void testCreateOfficerCompareMessage() throws InterruptedException {
+        compareCollection.expectedHeaderReceived("Src", "mock:officer_compare_src");
+        compareCollection.expectedHeaderReceived("SrcName", "Oracle");
+        compareCollection.expectedHeaderReceived("Target", "mock:officer_compare_target");
+        compareCollection.expectedHeaderReceived("TargetName", "MongoDB");
+        compareCollection.expectedHeaderReceived("Destination", "mock:result");
+        compareCollection.expectedHeaderReceived(MongoDbConstants.DISTINCT_QUERY_FIELD, "officer_id_raw");
+        compareCollection.expectedBodyReceived().constant("SELECT '1234567890' FROM DUAL");
+        producerTemplate.sendBody(0);
+        MockEndpoint.assertIsSatisfied(context);
+    }
+}

--- a/src/test/resources/application-stubbed.properties
+++ b/src/test/resources/application-stubbed.properties
@@ -15,4 +15,9 @@ query.oracle.corporate_body_collection=SELECT '12345678' FROM DUAL
 endpoint.mongodb.company_profile_collection=mock:fruitBasket
 function.name.compare_collection=mock:compare_collection
 
+endpoint.dsq_officer_collection.cron.tab=direct:dsq_officer_trigger
+endpoint.oracle.dsq_officer_collection=mock:officer_compare_src
+query.oracle.dsq_officer_collection=SELECT '1234567890' FROM DUAL
+endpoint.mongodb.disqualifications_collection=mock:officer_compare_target
+
 endpoint.output=mock:result


### PR DESCRIPTION
* Implement a new route to compare disqualified directors on Oracle with
the disqualifications collection on MongoDB.