### PR TITLE
BI-7526 Implement alpha search index comparator

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBAlphaSearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBAlphaSearch.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.reconciliation.company;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mongodb.MongoDbConstants;
+import org.springframework.stereotype.Component;
+
+/**
+ * Trigger a comparison between company profiles in MongoDB and company profiles that have been indexed in the
+ * Elasticsearch alphabetical search index.
+ */
+@Component
+public class CompanyNumberCompareMongoDBAlphaSearch extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("{{endpoint.company_collection_mongo_alpha.cron.tab}}")
+                .setHeader("MongoEndpoint", simple("{{endpoint.mongodb.company_profile_collection}}"))
+                .setHeader("MongoDescription", constant("MongoDB"))
+                .setHeader("MongoTargetHeader", constant("SrcList"))
+                .setHeader(MongoDbConstants.DISTINCT_QUERY_FIELD, constant("_id"))
+                .setHeader("Src", simple("{{endpoint.mongodb.collection}}"))
+                .setHeader("ElasticsearchEndpoint", simple("{{endpoint.elasticsearch.alpha}}"))
+                .setHeader("ElasticsearchQuery", simple("{{query.elasticsearch.alpha.company}}"))
+                .setHeader("ElasticsearchDescription", constant("Alpha Index"))
+                .setHeader("ElasticsearchTargetHeader", constant("TargetList"))
+                .setHeader("ElasticsearchLogIndices", simple("{{endpoint.elasticsearch.log_indices}}"))
+                .setHeader("Target", simple("{{endpoint.elasticsearch.collection}}"))
+                .setHeader("Destination", simple("{{endpoint.output}}"))
+                .to("{{function.name.compare_collection}}");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchScrollingSearchClient.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchScrollingSearchClient.java
@@ -60,7 +60,7 @@ public class ElasticsearchScrollingSearchClient implements AutoCloseable {
         searchRequest.scroll(new TimeValue(timeout, TimeUnit.SECONDS))
                 .source()
                 .query(searchSourceBuilder.query())
-                .slice(new SliceBuilder(sliceId, noOfSlices))
+                .slice(new SliceBuilder("_id", sliceId, noOfSlices))
                 .fetchSource(searchSourceBuilder.fetchSource())
                 .size(size);
         return client.search(searchRequest);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,9 +10,9 @@ endpoint.oracle.corporate_body_count=jdbc:dataSource?outputType=SelectOne
 query.oracle.corporate_body_count=resource:classpath:/sql/company_count.sql
 endpoint.mongodb.company_profile_count=mongodb:mongo?database=${ENDPOINT_MONGODB_COMPANY_PROFILE_DB_NAME}&collection=${ENDPOINT_MONGODB_COMPANY_PROFILE_COLLECTION_NAME}&operation=count&readPreference=${ENDPOINT_MONGODB_READ_PREFERENCE}
 
-# endpoint.elasticsearch.alpha=es-bulk-load://es_alpha?hostname=${ELASTICSEARCH_ALPHA_HOST}&indexName=${ELASTICSEARCH_ALPHA_INDEX}&portNumber=${ELASTICSEARCH_ALPHA_PORT}&protocol=${ELASTICSEARCH_ALPHA_PROTOCOL:https}&numberOfSegments=${ELASTICSEARCH_ALPHA_SEGMENTS}&maximumSliceSize=${ELASTICSEARCH_ALPHA_SLICE_SIZE}
+endpoint.elasticsearch.alpha=es-bulk-load://es_alpha?hostname=${ELASTICSEARCH_ALPHA_HOST}&indexName=${ELASTICSEARCH_ALPHA_INDEX}&portNumber=${ELASTICSEARCH_ALPHA_PORT}&protocol=${ELASTICSEARCH_ALPHA_PROTOCOL:https}&numberOfSegments=${ELASTICSEARCH_ALPHA_SEGMENTS}&maximumSliceSize=${ELASTICSEARCH_ALPHA_SLICE_SIZE}
 endpoint.elasticsearch.primary=es-bulk-load://es_alpha?hostname=${ELASTICSEARCH_PRIMARY_HOST}&indexName=${ELASTICSEARCH_PRIMARY_INDEX}&portNumber=${ELASTICSEARCH_PRIMARY_PORT}&protocol=${ELASTICSEARCH_PRIMARY_PROTOCOL:https}&numberOfSegments=${ELASTICSEARCH_PRIMARY_SEGMENTS}&maximumSliceSize=${ELASTICSEARCH_PRIMARY_SLICE_SIZE}
-# query.elasticsearch.alpha.all=resource:classpath:/elasticsearch/alpha.json
+query.elasticsearch.alpha.company=resource:classpath:/elasticsearch/alpha.json
 query.elasticsearch.primary.company=resource:classpath:/elasticsearch/primary_company.json
 
 endpoint.oracle.collection=direct:oracle-collection
@@ -27,6 +27,7 @@ endpoint.elasticsearch.log_indices=${ENDPOINT_ELASTICSEARCH_LOG_INDICES:100000}
 function.name.compare_collection=direct:compare_collection
 endpoint.company_collection.cron.tab=cron:company_collection?schedule=${COMPANY_COLLECTION_CRONTAB}
 endpoint.company_collection_mongo_primary.cron.tab=cron:company_collection_mongo_primary?schedule=${COMPANY_COLLECTION_MONGO_PRIMARY_CRONTAB}
+endpoint.company_collection_mongo_alpha.cron.tab=cron:company_collection_mongo_alpha?schedule=${COMPANY_COLLECTION_MONGO_ALPHA_CRONTAB}
 endpoint.oracle.corporate_body_collection=jdbc:dataSource
 query.oracle.corporate_body_collection=resource:classpath:/sql/company_collection.sql
 endpoint.mongodb.company_profile_collection=mongodb:mongo?database=${ENDPOINT_MONGODB_COMPANY_PROFILE_DB_NAME}&collection=${ENDPOINT_MONGODB_COMPANY_PROFILE_COLLECTION_NAME}&operation=findDistinct&readPreference=${ENDPOINT_MONGODB_READ_PREFERENCE}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/company/CompareNumberCompareMongoDBAlphaSearchTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/company/CompareNumberCompareMongoDBAlphaSearchTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.reconciliation.company;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.component.mongodb.MongoDbConstants;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@CamelSpringBootTest
+@SpringBootTest
+@DirtiesContext
+@TestPropertySource(locations = "classpath:application-stubbed.properties")
+public class CompareNumberCompareMongoDBAlphaSearchTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @EndpointInject("mock:compare_collection")
+    private MockEndpoint compareCollection;
+
+    @Produce("direct:company_collection_mongo_alpha_trigger")
+    private ProducerTemplate producerTemplate;
+
+    @AfterEach
+    void after() {
+        compareCollection.reset();
+    }
+
+    @Test
+    void testCorrectHeadersHasBeenSet() throws InterruptedException {
+        compareCollection.expectedHeaderReceived("MongoEndpoint", "mock:fruitBasket");
+        compareCollection.expectedHeaderReceived("MongoDescription", "MongoDB");
+        compareCollection.expectedHeaderReceived("MongoTargetHeader", "SrcList");
+        compareCollection.expectedHeaderReceived("Src", "direct:mongodb-collection");
+        compareCollection.expectedHeaderReceived("ElasticsearchEndpoint", "mock:elasticsearch-alpha-stub");
+        compareCollection.expectedHeaderReceived("ElasticsearchQuery", "alpha-test");
+        compareCollection.expectedHeaderReceived("ElasticsearchDescription", "Alpha Index");
+        compareCollection.expectedHeaderReceived("ElasticsearchTargetHeader", "TargetList");
+        compareCollection.expectedHeaderReceived("ElasticsearchLogIndices", "100000");
+        compareCollection.expectedHeaderReceived("Target", "direct:elasticsearch-collection");
+        compareCollection.expectedHeaderReceived("Destination", "mock:result");
+        compareCollection.expectedHeaderReceived(MongoDbConstants.DISTINCT_QUERY_FIELD, "_id");
+        producerTemplate.sendBody(0);
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+}

--- a/src/test/resources/application-stubbed.properties
+++ b/src/test/resources/application-stubbed.properties
@@ -17,11 +17,15 @@ function.name.compare_collection=mock:compare_collection
 
 endpoint.company_collection_mongo_primary.cron.tab=direct:company_collection_mongo_primary_trigger
 endpoint.elasticsearch.primary=mock:elasticsearch-stub
+endpoint.elasticsearch.alpha=mock:elasticsearch-alpha-stub
 query.elasticsearch.primary.company=test
+query.elasticsearch.alpha.company=alpha-test
 
 endpoint.dsq_officer_collection.cron.tab=direct:dsq_officer_trigger
 endpoint.oracle.dsq_officer_collection=mock:officer_compare_src
 query.oracle.dsq_officer_collection=SELECT '1234567890' FROM DUAL
 endpoint.mongodb.disqualifications_collection=mock:officer_compare_target
+
+endpoint.company_collection_mongo_alpha.cron.tab=direct:company_collection_mongo_alpha_trigger
 
 endpoint.output=mock:result


### PR DESCRIPTION
* Implement comparator to compare companies in MongoDB with companies
loaded into the Elasticsearch alpha index.