### PR TITLE
BI-7703 Publish primary index, mongo comparison

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBPrimarySearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBPrimarySearch.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.reconciliation.company;
 
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.apache.camel.component.mongodb.MongoDbConstants;
 import org.springframework.stereotype.Component;
 
@@ -26,7 +27,11 @@ public class CompanyNumberCompareMongoDBPrimarySearch extends RouteBuilder {
                 .setHeader("ElasticsearchLogIndices", simple("{{endpoint.elasticsearch.log_indices}}"))
                 .setHeader("Target", simple("{{endpoint.elasticsearch.collection}}"))
                 .setHeader("Comparison", simple("primary search index"))
-                .setHeader("Destination", simple("{{endpoint.log.output}}"))
+                .setHeader("Destination", simple("{{endpoint.output}}"))
+                .setHeader("Upload", simple("{{endpoint.s3.upload}}"))
+                .setHeader("Presign", simple("{{endpoint.s3presigner.download}}"))
+                .setHeader(AWS2S3Constants.KEY, simple("company/collection_primary_mongo_${date:now:yyyyMMdd}T${date:now:hhmmss}.csv"))
+                .setHeader(AWS2S3Constants.DOWNLOAD_LINK_EXPIRATION_TIME, simple("{{aws.expiry}}"))
                 .to("{{function.name.compare_collection}}");
     }
 }

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendEmailRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendEmailRoute.java
@@ -15,7 +15,7 @@ public class SendEmailRoute extends RouteBuilder {
 
         from("direct:send-email")
                 .aggregate(constant(true), new EmailAggregationStrategy())
-                .completionSize(2)
+                .completionSize(3)
                 .to("{{endpoint.kafka.sender}}");
     }
 }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/company/CompareNumberCompareMongoDBPrimarySearchTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/company/CompareNumberCompareMongoDBPrimarySearchTest.java
@@ -46,7 +46,7 @@ public class CompareNumberCompareMongoDBPrimarySearchTest {
         compareCollection.expectedHeaderReceived("ElasticsearchTargetHeader", "TargetList");
         compareCollection.expectedHeaderReceived("ElasticsearchLogIndices", "100000");
         compareCollection.expectedHeaderReceived("Target", "direct:elasticsearch-collection");
-        compareCollection.expectedHeaderReceived("Destination", "mock:log-result");
+        compareCollection.expectedHeaderReceived("Destination", "mock:result");
         compareCollection.expectedHeaderReceived(MongoDbConstants.DISTINCT_QUERY_FIELD, "_id");
         producerTemplate.sendBody(0);
         MockEndpoint.assertIsSatisfied(context);


### PR DESCRIPTION
* Upload results of comparison between Elasticsearch primary index and
MongoDB to S3 bucket and include in company profile email that is
distributed.