### PR TITLE
Fix typo in test application properties

### DIFF
--- a/src/test/java/uk/gov/companieshouse/reconciliation/email/SendEmailRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/email/SendEmailRouteTest.java
@@ -34,9 +34,6 @@ public class SendEmailRouteTest {
     @EndpointInject("mock:kafka-endpoint")
     private MockEndpoint kafkaEndpoint;
 
-    @EndpointInject("mock:second-kafka-endpoint")
-    private MockEndpoint secondKafkaEndpoint;
-
     @Produce("direct:send-email")
     private ProducerTemplate producerTemplate;
 

--- a/src/test/resources/application-stubbed.properties
+++ b/src/test/resources/application-stubbed.properties
@@ -32,7 +32,7 @@ endpoint.s3presigner.download=mock:s3_download_link
 aws.expiry=2000
 endpoint.output=mock:result
 endpoint.log.output=mock:log-result
-endpoint.kafka-sender=mock:kafka-endpoint
+endpoint.kafka.sender=mock:kafka-endpoint
 
 results.initial.capacity=16
 


### PR DESCRIPTION
* Fix test failure caused by incorrect property name in test application properties.