### PR TITLE
BI-7525 Compare company names between MongoDB and alpha index

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearch.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.reconciliation.company;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.s3.AWS2S3Constants;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CompanyNameCompareMongoDBAlphaSearch extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("{{endpoint.company_name_mongo_alpha.cron.tab}}")
+                .setHeader("Src").constant("{{endpoint.mongodb.wrapper.company_profile.collection}}")
+                .setHeader("SrcDescription").constant("MongoDB - Company Profile")
+                .setHeader("Target").constant("{{endpoint.elasticsearch.collection}}")
+                .setHeader("TargetDescription").constant("Alpha Index")
+                .setHeader("ElasticsearchEndpoint").constant("{{endpoint.elasticsearch.alpha}}")
+                .setHeader("ElasticsearchQuery").constant("{{query.elasticsearch.alpha.company}}")
+                .setHeader("ElasticsearchCacheKey").constant("{{endpoint.elasticsearch.alpha.cache.key}}")
+                .setHeader("RecordType").constant("Company Number")
+                .setHeader("Destination").constant("{{endpoint.elasticsearch.output}}")
+                .setHeader("Upload", constant("{{endpoint.s3.upload}}"))
+                .setHeader("Presign", constant("{{endpoint.s3presigner.download}}"))
+                .setHeader(AWS2S3Constants.KEY, simple("company/results_alpha_mongo_${date:now:yyyyMMdd}T${date:now:hhmmss}.csv"))
+                .setHeader(AWS2S3Constants.DOWNLOAD_LINK_EXPIRATION_TIME, constant("{{aws.expiry}}"))
+                .to("{{function.name.compare_results}}");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearch.java
@@ -4,6 +4,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.aws2.s3.AWS2S3Constants;
 import org.springframework.stereotype.Component;
 
+/**
+ * Trigger a comparison between company profiles in MongoDB and company profiles that have been indexed in the
+ * Elasticsearch alphabetical search index. Any differences between company names will be recorded in the results.
+ */
 @Component
 public class CompanyNameCompareMongoDBAlphaSearch extends RouteBuilder {
 
@@ -18,7 +22,8 @@ public class CompanyNameCompareMongoDBAlphaSearch extends RouteBuilder {
                 .setHeader("ElasticsearchQuery").constant("{{query.elasticsearch.alpha.company}}")
                 .setHeader("ElasticsearchCacheKey").constant("{{endpoint.elasticsearch.alpha.cache.key}}")
                 .setHeader("ElasticsearchTransformer").constant("{{transformer.elasticsearch.alpha}}")
-                .setHeader("RecordType").constant("Company Number")
+                .setHeader("RecordKey").constant("Company Number")
+                .setHeader("Comparison").constant("company names")
                 .setHeader("Destination").constant("{{endpoint.elasticsearch.output}}")
                 .setHeader("Upload", constant("{{endpoint.s3.upload}}"))
                 .setHeader("Presign", constant("{{endpoint.s3presigner.download}}"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearch.java
@@ -17,6 +17,7 @@ public class CompanyNameCompareMongoDBAlphaSearch extends RouteBuilder {
                 .setHeader("ElasticsearchEndpoint").constant("{{endpoint.elasticsearch.alpha}}")
                 .setHeader("ElasticsearchQuery").constant("{{query.elasticsearch.alpha.company}}")
                 .setHeader("ElasticsearchCacheKey").constant("{{endpoint.elasticsearch.alpha.cache.key}}")
+                .setHeader("ElasticsearchTransformer").constant("{{transformer.elasticsearch.alpha}}")
                 .setHeader("RecordType").constant("Company Number")
                 .setHeader("Destination").constant("{{endpoint.elasticsearch.output}}")
                 .setHeader("Upload", constant("{{endpoint.s3.upload}}"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBPrimarySearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBPrimarySearch.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Trigger a comparison between company profiles in MongoDB and company profiles that have been indexed in the
- * Elasticsearch alphabetical search index. Any differences between company names will be recorded in the results.
+ * Elasticsearch primary search index. Any differences between company names will be recorded in the results.
  */
 @Component
 public class CompanyNameCompareMongoDBPrimarySearch extends RouteBuilder {
@@ -22,7 +22,8 @@ public class CompanyNameCompareMongoDBPrimarySearch extends RouteBuilder {
                 .setHeader("ElasticsearchQuery").constant("{{query.elasticsearch.primary.company}}")
                 .setHeader("ElasticsearchCacheKey").constant("{{endpoint.elasticsearch.primary.cache.key}}")
                 .setHeader("ElasticsearchTransformer").constant("{{transformer.elasticsearch.primary}}")
-                .setHeader("RecordType").constant("Company Number")
+                .setHeader("RecordKey").constant("Company Number")
+                .setHeader("Comparison").constant("company names")
                 .setHeader("Destination").constant("{{endpoint.elasticsearch.output}}")
                 .setHeader("Upload", constant("{{endpoint.s3.upload}}"))
                 .setHeader("Presign", constant("{{endpoint.s3presigner.download}}"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBPrimarySearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBPrimarySearch.java
@@ -21,6 +21,7 @@ public class CompanyNameCompareMongoDBPrimarySearch extends RouteBuilder {
                 .setHeader("ElasticsearchEndpoint").constant("{{endpoint.elasticsearch.primary}}")
                 .setHeader("ElasticsearchQuery").constant("{{query.elasticsearch.primary.company}}")
                 .setHeader("ElasticsearchCacheKey").constant("{{endpoint.elasticsearch.primary.cache.key}}")
+                .setHeader("ElasticsearchTransformer").constant("{{transformer.elasticsearch.primary}}")
                 .setHeader("RecordType").constant("Company Number")
                 .setHeader("Destination").constant("{{endpoint.elasticsearch.output}}")
                 .setHeader("Upload", constant("{{endpoint.s3.upload}}"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBAlphaSearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBAlphaSearch.java
@@ -25,6 +25,7 @@ public class CompanyNumberCompareMongoDBAlphaSearch extends RouteBuilder {
                 .setHeader("ElasticsearchTargetHeader", constant("TargetList"))
                 .setHeader("ElasticsearchLogIndices", simple("{{endpoint.elasticsearch.log_indices}}"))
                 .setHeader("ElasticsearchCacheKey", constant("{{endpoint.elasticsearch.alpha.cache.key}}"))
+                .setHeader("ElasticsearchTransformer", constant("{{transformer.elasticsearch.alpha}}"))
                 .setHeader("Target", constant("{{endpoint.elasticsearch.collection.company_number}}"))
                 .setHeader("Comparison", constant("company numbers"))
                 .setHeader("RecordType", constant("Company Number"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBPrimarySearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyNumberCompareMongoDBPrimarySearch.java
@@ -25,6 +25,7 @@ public class CompanyNumberCompareMongoDBPrimarySearch extends RouteBuilder {
                 .setHeader("ElasticsearchTargetHeader", constant("TargetList"))
                 .setHeader("ElasticsearchLogIndices", simple("{{endpoint.elasticsearch.log_indices}}"))
                 .setHeader("ElasticsearchCacheKey", constant("{{endpoint.elasticsearch.primary.cache.key}}"))
+                .setHeader("ElasticsearchTransformer", constant("{{transformer.elasticsearch.primary}}"))
                 .setHeader("Target", constant("{{endpoint.elasticsearch.collection.company_number}}"))
                 .setHeader("Comparison", constant("company numbers"))
                 .setHeader("RecordType", constant("Company Number"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRoute.java
@@ -43,7 +43,7 @@ public class CompareResultsRoute extends RouteBuilder {
                 .toD("${header.Upload}")
                 .toD("${header.Presign}")
                 .setHeader("ResourceLinkReference", body())
-                .setHeader("ResourceLinkDescription").simple("Comparisons completed for ${header.RecordType} in ${header.SrcDescription} and ${header.TargetDescription}.")
+                .setHeader("ResourceLinkDescription").simple("Comparisons completed for ${header.Comparison} in ${header.SrcDescription} and ${header.TargetDescription}.")
                 .log("Compare Results: ${header.ResourceLinkDescription}")
                 .toD("${header.Destination}");
     }

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/transformer/CompareResultsTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/transformer/CompareResultsTransformer.java
@@ -25,21 +25,21 @@ public class CompareResultsTransformer {
      * @param srcDescription A description of the first endpoint from which {@link Results results} have been retrieved.
      * @param targetResults A {@link Results results object} containing data retrieved from another endpoint.
      * @param targetDescription A description of the second endpoint from which {@link Results results} have been retrieved.
-     * @param recordType A description of the type of data being compared.
+     * @param recordKey A description of the type of data being compared.
      * @return A {@link List list} containing {@link Map company number and data name-value pairings}.
      */
     public List<Map<String, Object>> transform(@Header("SrcList") Results srcResults,
                                                @Header("SrcDescription") String srcDescription,
                                                @Header("TargetList") Results targetResults,
                                                @Header("TargetDescription") String targetDescription,
-                                               @Header("RecordType") String recordType) {
+                                               @Header("RecordKey") String recordKey) {
 
         // Calculate intersection of both Results objects.
         // Remap Results objects to maps of company number and company name pairings.
         // If value in one map is different add it to the results.
         List<Map<String, Object>> results = new ArrayList<>();
 
-        addRow(results, recordType, recordType, srcDescription, srcDescription,
+        addRow(results, recordKey, recordKey, srcDescription, srcDescription,
                 targetDescription, targetDescription);
 
         Map<String, String> srcModels = generateMappings(srcResults.getResultModels());
@@ -50,7 +50,7 @@ public class CompareResultsTransformer {
                         targetModels.containsKey(entry.getKey()) && !targetModels.get(entry.getKey()).equals(entry.getValue())
                 )
                 .forEach(entry ->
-                        addRow(results, recordType, entry.getKey(), srcDescription, entry.getValue(),
+                        addRow(results, recordKey, entry.getKey(), srcDescription, entry.getValue(),
                                 targetDescription, targetModels.get(entry.getKey()))
                 );
 

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendElasticsearchEmailRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendElasticsearchEmailRoute.java
@@ -11,7 +11,7 @@ public class SendElasticsearchEmailRoute extends RouteBuilder {
     public void configure() throws Exception {
         from("direct:send-elasticsearch-email")
                 .aggregate(constant(true), new EmailAggregationStrategy())
-                .completionSize(3)
+                .completionSize(4)
                 .setHeader("CompletionDate", simple("${date:now:dd MMMM yyyy}"))
                 .setHeader("EmailSubject", simple("Elasticsearch comparisons (${header.CompletionDate})"))
                 .to("{{endpoint.kafka.sender}}");

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchCollectionRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchCollectionRoute.java
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Component;
  * header(ElasticsearchQuery): The query that will be run against Elasticsearch.<br>
  * header(ElasticsearchLogIndices): An {@link java.lang.Integer integer} used to determine the interval at which the
  * number of search hits will be logged.<br>
+ * header(ElasticsearchCacheKey): The key under which results will be cached.<br>
+ * header(ElasticsearchEndpoint): The Elasticsearch service that indices will be fetched from.<br>
+ * header(ElasticsearchTransformer): The name of the route responsible for transforming indices returned by
+ * Elasticsearch.
  */
 @Component
 public class ElasticsearchCollectionRoute extends RouteBuilder {

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchCollectionRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchCollectionRoute.java
@@ -26,7 +26,7 @@ public class ElasticsearchCollectionRoute extends RouteBuilder {
                 .when(header(CaffeineConstants.ACTION_HAS_RESULT).isEqualTo(false))
                     .setBody(header("ElasticsearchQuery"))
                     .toD("${header.ElasticsearchEndpoint}")
-                    .bean(ElasticsearchTransformer.class)
+                    .toD("${header.ElasticsearchTransformer}")
                     .log("${body.size()} results have been fetched from elasticsearch.")
                     .setHeader(CaffeineConstants.ACTION, constant(CaffeineConstants.ACTION_PUT))
                     .setHeader(CaffeineConstants.KEY, simple("${header.ElasticsearchCacheKey}"))

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchResultMappable.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchResultMappable.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch;
+
+import org.elasticsearch.search.SearchHit;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+
+/**
+ * Maps fields from a single {@link SearchHit search hit} returned by Elasticsearch to a
+ * {@link ResultModel result model}.
+ */
+public interface ElasticsearchResultMappable {
+    /**
+     * Map ID and source fields of a {@link SearchHit search hit} to a {@link ResultModel result model}.
+     *
+     * @param hit A single {@link SearchHit search hit} returned by Elasticsearch.
+     * @return A {@link ResultModel result model} mapped from the {@link SearchHit search hit object}.
+     */
+    ResultModel mapWithSourceFields(SearchHit hit);
+
+    /**
+     * Map a {@link SearchHit search hit} excluding source fields to a {@link ResultModel result model}.
+     *
+     * @param hit A single {@link SearchHit search hit} returned by Elasticsearch.
+     * @return A {@link ResultModel result model} mapped from the {@link SearchHit search hit object}.
+     */
+    ResultModel mapExcludingSourceFields(SearchHit hit);
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchTransformer.java
@@ -5,29 +5,27 @@ import org.apache.camel.Header;
 import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.reconciliation.model.ResultModel;
 import uk.gov.companieshouse.reconciliation.model.Results;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.primary.ElasticsearchPrimaryIndexTransformer;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * Transform {@link SearchHit search hits} retrieved from an Elasticsearch index into a collection
  * of {@link Results results}.
  */
-@Component
-public class ElasticsearchTransformer {
+public abstract class ElasticsearchTransformer {
 
-    @Value("${results.initial.capacity}")
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchPrimaryIndexTransformer.class);
     private int initialCapacity;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchTransformer.class);
+    public ElasticsearchTransformer(int initialCapacity) {
+        this.initialCapacity = initialCapacity;
+    }
 
     /**
      * Iterate over {@link SearchHit search hits} retrieved from an Elasticsearch index and map ID and corporate body
@@ -58,13 +56,5 @@ public class ElasticsearchTransformer {
         return results;
     }
 
-    private void addSourceFieldToNameList(List<String> names, SearchHit hit, String sourceField) {
-        Optional.ofNullable(hit.getSourceAsMap().get("items"))
-                .flatMap(items -> ((List<?>)items).stream().findFirst())
-                .map(item -> ((Map<?,?>)item).get(sourceField))
-                .map(Object::toString)
-                .map(String::trim)
-                .filter(nameEnding -> !nameEnding.isEmpty())
-                .ifPresent(names::add);
-    }
+    protected abstract void addSourceFieldToNameList(List<String> names, SearchHit hit, String sourceField);
 }

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapper.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapper.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
+
+import org.elasticsearch.search.SearchHit;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchResultMappable;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class ElasticsearchAlphaIndexResultMapper implements ElasticsearchResultMappable {
+
+    @Override
+    public ResultModel mapWithSourceFields(SearchHit hit) {
+        String corporateName = getSourceField(hit, "corporate_name");
+        return new ResultModel(hit.getId(), corporateName);
+    }
+
+    @Override
+    public ResultModel mapExcludingSourceFields(SearchHit hit) {
+        return new ResultModel(hit.getId(), "");
+    }
+
+    private String getSourceField(SearchHit hit, String sourceField) {
+        return Optional.ofNullable(hit.getSourceAsMap().get("items"))
+                .map(item -> ((Map<?,?>)item).get(sourceField))
+                .map(Object::toString)
+                .map(String::trim)
+                .filter(nameEnding -> !nameEnding.isEmpty())
+                .orElse("");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRoute.java
@@ -3,6 +3,13 @@ package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.stereotype.Component;
 
+/**
+ * Transform indices returned by Elasticsearch alpha index.
+ * <br>
+ * IN:<br>
+ * body(): An {@link java.util.Iterator iterator} from which {@link org.elasticsearch.search.SearchHit search hits}
+ * can be obtained.
+ */
 @Component
 public class ElasticsearchAlphaIndexRoute extends RouteBuilder {
 

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRoute.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ElasticsearchAlphaIndexRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("direct:elasticsearch-alpha")
+                .bean(ElasticsearchAlphaIndexTransformer.class);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexTransformer.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
+
+import org.elasticsearch.search.SearchHit;
+import org.springframework.beans.factory.annotation.Value;
+import uk.gov.companieshouse.reconciliation.model.Results;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchTransformer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Transform {@link SearchHit search hits} retrieved from the Elasticsearch alphabetical index into a collection
+ * of {@link Results results}.
+ */
+public class ElasticsearchAlphaIndexTransformer extends ElasticsearchTransformer {
+
+    public ElasticsearchAlphaIndexTransformer(@Value("${results.initial.capacity}") int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    @Override
+    protected void addSourceFieldToNameList(List<String> names, SearchHit hit, String sourceField) {
+        Optional.ofNullable(hit.getSourceAsMap().get("items"))
+                .map(item -> ((Map<?,?>)item).get(sourceField))
+                .map(Object::toString)
+                .map(String::trim)
+                .filter(nameEnding -> !nameEnding.isEmpty())
+                .ifPresent(names::add);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexResultMapper.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexResultMapper.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
+
+import org.elasticsearch.search.SearchHit;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchResultMappable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class ElasticsearchPrimaryIndexResultMapper implements ElasticsearchResultMappable {
+
+    @Override
+    public ResultModel mapWithSourceFields(SearchHit hit) {
+        List<String> names = new ArrayList<>();
+        addSourceFieldToNameList(names, hit, "corporate_name_start");
+        addSourceFieldToNameList(names, hit, "corporate_name_ending");
+        return new ResultModel(hit.getId(), String.join(" ", names));
+    }
+
+    @Override
+    public ResultModel mapExcludingSourceFields(SearchHit hit) {
+        return new ResultModel(hit.getId(), "");
+    }
+
+    private void addSourceFieldToNameList(List<String> names, SearchHit hit, String sourceField) {
+        Optional.ofNullable(hit.getSourceAsMap().get("items"))
+                .flatMap(items -> ((List<?>)items).stream().findFirst())
+                .map(item -> ((Map<?,?>)item).get(sourceField))
+                .map(Object::toString)
+                .map(String::trim)
+                .filter(nameEnding -> !nameEnding.isEmpty())
+                .ifPresent(names::add);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexRoute.java
@@ -3,6 +3,13 @@ package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.stereotype.Component;
 
+/**
+ * Transform indices returned by Elasticsearch primary index.<br>
+ * <br>
+ * IN:<br>
+ * body(): An {@link java.util.Iterator iterator} from which {@link org.elasticsearch.search.SearchHit search hits}
+ * can be obtained.
+ */
 @Component
 public class ElasticsearchPrimaryIndexRoute extends RouteBuilder {
 

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexRoute.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ElasticsearchPrimaryIndexRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("direct:elasticsearch-primary")
+                .bean(ElasticsearchPrimaryIndexTransformer.class);
+    }
+}
+

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformer.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
+
+import org.elasticsearch.search.SearchHit;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.reconciliation.model.Results;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchTransformer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Transform {@link SearchHit search hits} retrieved from the Elasticsearch primary index into a collection
+ * of {@link Results results}.
+ */
+@Component
+public class ElasticsearchPrimaryIndexTransformer extends ElasticsearchTransformer {
+
+    public ElasticsearchPrimaryIndexTransformer(@Value("${results.initial.capacity}") int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    protected void addSourceFieldToNameList(List<String> names, SearchHit hit, String sourceField) {
+        Optional.ofNullable(hit.getSourceAsMap().get("items"))
+                .flatMap(items -> ((List<?>)items).stream().findFirst())
+                .map(item -> ((Map<?,?>)item).get(sourceField))
+                .map(Object::toString)
+                .map(String::trim)
+                .filter(nameEnding -> !nameEnding.isEmpty())
+                .ifPresent(names::add);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformer.java
@@ -1,33 +1,33 @@
 package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
 
+import org.apache.camel.Body;
+import org.apache.camel.Header;
 import org.elasticsearch.search.SearchHit;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.reconciliation.model.Results;
 import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchTransformer;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.Iterator;
 
 /**
  * Transform {@link SearchHit search hits} retrieved from the Elasticsearch primary index into a collection
  * of {@link Results results}.
  */
 @Component
-public class ElasticsearchPrimaryIndexTransformer extends ElasticsearchTransformer {
+public class ElasticsearchPrimaryIndexTransformer {
 
-    public ElasticsearchPrimaryIndexTransformer(@Value("${results.initial.capacity}") int initialCapacity) {
-        super(initialCapacity);
+    private final ElasticsearchTransformer resultTransformer;
+
+    private final ElasticsearchPrimaryIndexResultMapper searchHitMapper;
+
+    @Autowired
+    public ElasticsearchPrimaryIndexTransformer(ElasticsearchTransformer resultTransformer, ElasticsearchPrimaryIndexResultMapper searchHitMapper) {
+        this.resultTransformer = resultTransformer;
+        this.searchHitMapper = searchHitMapper;
     }
 
-    protected void addSourceFieldToNameList(List<String> names, SearchHit hit, String sourceField) {
-        Optional.ofNullable(hit.getSourceAsMap().get("items"))
-                .flatMap(items -> ((List<?>)items).stream().findFirst())
-                .map(item -> ((Map<?,?>)item).get(sourceField))
-                .map(Object::toString)
-                .map(String::trim)
-                .filter(nameEnding -> !nameEnding.isEmpty())
-                .ifPresent(names::add);
+    public Results transform(@Body Iterator<SearchHit> it, @Header("ElasticsearchLogIndices") Integer logIndices) {
+        return resultTransformer.transform(it, logIndices, searchHitMapper);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,7 @@ endpoint.company_collection_mongo_primary.cron.tab=cron:company_collection_mongo
 endpoint.company_collection_mongo_alpha.cron.tab=cron:company_collection_mongo_alpha?schedule=${COMPANY_COLLECTION_MONGO_ALPHA_CRONTAB}
 endpoint.dsq_officer_collection.cron.tab=cron:dsq_officer_collection?schedule=${DSQ_OFFICER_COLLECTION_CRONTAB}
 endpoint.company_name_mongo_primary.cron.tab=cron:company_name_mongo_primary?schedule=${COMPANY_NAME_MONGO_PRIMARY_CRONTAB}
+endpoint.company_name_mongo_alpha.cron.tab=cron:company_name_mongo_alpha?schedule=${COMPANY_NAME_MONGO_ALPHA_CRONTAB}
 
 # Functions
 function.name.compare_count=direct:compare_count

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -74,6 +74,10 @@ endpoint.mongodb.wrapper.company_profile.collection=direct:mongodb-company_profi
 endpoint.mongodb.wrapper.disqualifications.collection=direct:mongodb-disqualifications-collection
 endpoint.elasticsearch.collection=direct:elasticsearch-collection
 
+# Service wrapper transformers
+transformer.elasticsearch.primary=direct:elasticsearch-primary
+transformer.elasticsearch.alpha=direct:elasticsearch-alpha
+
 # Misc
 endpoint.log.output=log:output
 results.initial.capacity=${RESULTS_INITIAL_CAPACITY}

--- a/src/main/resources/elasticsearch/alpha.json
+++ b/src/main/resources/elasticsearch/alpha.json
@@ -4,8 +4,7 @@
   },
   "_source": {
     "includes": [
-      "items.corporate_name_start",
-      "items.corporate_name_ending"
+      "items.corporate_name"
     ]
   }
 }

--- a/src/main/resources/elasticsearch/alpha.json
+++ b/src/main/resources/elasticsearch/alpha.json
@@ -2,5 +2,10 @@
   "query": {
     "match_all": {}
   },
-  "_source": false
+  "_source": {
+    "includes": [
+      "items.corporate_name_start",
+      "items.corporate_name_ending"
+    ]
+  }
 }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearchTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearchTest.java
@@ -43,7 +43,8 @@ public class CompanyNameCompareMongoDBAlphaSearchTest {
         target.expectedHeaderReceived("ElasticsearchCacheKey", "elasticsearchAlpha");
         target.expectedHeaderReceived("ElasticsearchEndpoint", "mock:elasticsearch-alpha-stub");
         target.expectedHeaderReceived("ElasticsearchQuery", "alpha-test");
-        target.expectedHeaderReceived("RecordType", "Company Number");
+        target.expectedHeaderReceived("RecordKey", "Company Number");
+        target.expectedHeaderReceived("Comparison", "company names");
         target.expectedHeaderReceived("Destination", "mock:elasticsearch");
         target.expectedHeaderReceived("Upload", "mock:s3_bucket_destination");
         target.expectedHeaderReceived("Presign", "mock:s3_download_link");

--- a/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearchTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBAlphaSearchTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.reconciliation.company;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.aws2.s3.AWS2S3Constants;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@CamelSpringBootTest
+@SpringBootTest
+@DirtiesContext
+@TestPropertySource(locations = "classpath:application-stubbed.properties")
+public class CompanyNameCompareMongoDBAlphaSearchTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @EndpointInject("mock:compare_results")
+    private MockEndpoint target;
+
+    @Produce("direct:company_name_mongo_alpha_trigger")
+    private ProducerTemplate producerTemplate;
+
+    @BeforeEach
+    void setUp() {
+        target.reset();
+    }
+
+    @Test
+    void testSetHeadersAndProduceMessage() throws InterruptedException {
+        target.expectedHeaderReceived("Src", "mock:mongoCompanyProfileCollection");
+        target.expectedHeaderReceived("SrcDescription", "MongoDB - Company Profile");
+        target.expectedHeaderReceived("Target", "mock:elasticsearch-collection");
+        target.expectedHeaderReceived("TargetDescription", "Alpha Index");
+        target.expectedHeaderReceived("ElasticsearchCacheKey", "elasticsearchAlpha");
+        target.expectedHeaderReceived("ElasticsearchEndpoint", "mock:elasticsearch-alpha-stub");
+        target.expectedHeaderReceived("ElasticsearchQuery", "alpha-test");
+        target.expectedHeaderReceived("RecordType", "Company Number");
+        target.expectedHeaderReceived("Destination", "mock:elasticsearch");
+        target.expectedHeaderReceived("Upload", "mock:s3_bucket_destination");
+        target.expectedHeaderReceived("Presign", "mock:s3_download_link");
+        target.expectedHeaderReceived(AWS2S3Constants.DOWNLOAD_LINK_EXPIRATION_TIME, 2000L);
+        producerTemplate.sendBody(0);
+        MockEndpoint.assertIsSatisfied(context);
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBPrimarySearchTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyNameCompareMongoDBPrimarySearchTest.java
@@ -44,7 +44,8 @@ public class CompanyNameCompareMongoDBPrimarySearchTest {
         target.expectedHeaderReceived("ElasticsearchCacheKey", "elasticsearchPrimary");
         target.expectedHeaderReceived("ElasticsearchEndpoint", "mock:elasticsearch-stub");
         target.expectedHeaderReceived("ElasticsearchQuery", "test");
-        target.expectedHeaderReceived("RecordType", "Company Number");
+        target.expectedHeaderReceived("RecordKey", "Company Number");
+        target.expectedHeaderReceived("Comparison", "company names");
         target.expectedHeaderReceived("Destination", "mock:elasticsearch");
         target.expectedHeaderReceived("Upload", "mock:s3_bucket_destination");
         target.expectedHeaderReceived("Presign", "mock:s3_download_link");

--- a/src/test/java/uk/gov/companieshouse/reconciliation/email/SendElasticsearchEmailRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/email/SendElasticsearchEmailRouteTest.java
@@ -50,7 +50,7 @@ public class SendElasticsearchEmailRouteTest {
                 interceptSendToEndpoint("mock:kafka-endpoint")
                         .process(exchange -> {
                             ResourceLinksWrapper downloadsList = exchange.getIn().getHeader("ResourceLinks", ResourceLinksWrapper.class);
-                            assertEquals(3, downloadsList.getDownloadLinkList().size());
+                            assertEquals(4, downloadsList.getDownloadLinkList().size());
                         });
             }
         });
@@ -68,10 +68,15 @@ public class SendElasticsearchEmailRouteTest {
                 .withHeader("ResourceLinkReference", "Compare Number Primary Mongo Link")
                 .build();
 
+        Exchange fourthExchange = ExchangeBuilder.anExchange(context)
+                .withHeader("ResourceLinkReference", "Compare Name Alpha Mongo Link")
+                .build();
+
         kafkaEndpoint.expectedMessageCount(1);
         producerTemplate.send(firstExchange);
         producerTemplate.send(secondExchange);
         producerTemplate.send(thirdExchange);
+        producerTemplate.send(fourthExchange);
 
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRouteTest.java
@@ -56,7 +56,7 @@ public class CompareResultsRouteTest {
         srcEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(srcResults));
         targetEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(targetResults));
         output.allMessages().body().isEqualTo("Company Number,MongoDB - Company Profile,Primary Search Index\r\n12345678,ACME LTD,ACME LIMITED\r\n");
-        output.expectedHeaderReceived("ResourceLinkDescription", "Comparisons completed for Company Number in MongoDB - Company Profile and Primary Search Index.");
+        output.expectedHeaderReceived("ResourceLinkDescription", "Comparisons completed for companies in MongoDB - Company Profile and Primary Search Index.");
 
         // when
         producerTemplate.sendBodyAndHeaders(0, createHeaders());
@@ -69,7 +69,8 @@ public class CompareResultsRouteTest {
         headers.put("Target", "mock:target-endpoint");
         headers.put("SrcDescription", "MongoDB - Company Profile");
         headers.put("TargetDescription", "Primary Search Index");
-        headers.put("RecordType", "Company Number");
+        headers.put("RecordKey", "Company Number");
+        headers.put("Comparison", "companies");
         headers.put("Destination", "mock:log-result");
         return headers;
     }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/ElasticsearchTransformerTest.java
@@ -1,0 +1,86 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch;
+
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+import uk.gov.companieshouse.reconciliation.model.Results;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchTransformerTest {
+
+    @Mock
+    private SearchHit searchHit;
+
+    @Mock
+    private ElasticsearchSlicedScrollIterator iterator;
+
+    @Mock
+    private ResultModel resultModel;
+
+    @Mock
+    private ElasticsearchResultMappable mappingFunction;
+
+    private ElasticsearchTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new ElasticsearchTransformer(1);
+    }
+
+    @Test
+    void testReturnEmptyResultsObjectIfNoHitsReturned() {
+        //given
+        when(iterator.hasNext()).thenReturn(false);
+
+        //when
+        Results actual = transformer.transform(iterator, 1, mappingFunction);
+
+        //then
+        assertEquals(0, actual.size());
+        verifyNoInteractions(mappingFunction);
+    }
+
+    @Test
+    void testReturnResultsSourceFieldsIncluded() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        when(iterator.next()).thenReturn(searchHit);
+        when(searchHit.hasSource()).thenReturn(true);
+        when(mappingFunction.mapWithSourceFields(any())).thenReturn(resultModel);
+
+        //when
+        Results actual = transformer.transform(iterator, 1, mappingFunction);
+
+        //then
+        assertSame(resultModel, actual.getResultModels().iterator().next());
+        verify(mappingFunction).mapWithSourceFields(searchHit);
+    }
+
+    @Test
+    void testReturnResultsSourceFieldsExcluded() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        when(iterator.next()).thenReturn(searchHit);
+        when(searchHit.hasSource()).thenReturn(false);
+        when(mappingFunction.mapExcludingSourceFields(any())).thenReturn(resultModel);
+
+        //when
+        Results actual = transformer.transform(iterator, 1, mappingFunction);
+
+        //then
+        assertSame(resultModel, actual.getResultModels().iterator().next());
+        verify(mappingFunction).mapExcludingSourceFields(searchHit);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapperTest.java
@@ -1,0 +1,104 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ElasticsearchAlphaIndexResultMapperTest {
+
+    private ElasticsearchAlphaIndexResultMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ElasticsearchAlphaIndexResultMapper();
+    }
+
+    @Test
+    void testMapSearchHitToResultModel() {
+        //given
+        String source = "{ \"items\": {\"corporate_name\": \"ACME LIMITED\"} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", "ACME LIMITED"), actual);
+    }
+
+    @Test
+    void testMapSearchHitWithoutSourceFields() {
+        //given
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+
+        //when
+        ResultModel actual = mapper.mapExcludingSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitReplaceNullValuesWithEmptyStrings() {
+        //given
+        String source = "{ \"items\": {\"corporate_name\": null} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitHandleEmptyItemsObject() {
+        //given
+        String source = "{ \"items\": {} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitHandleNullItems() {
+        //given
+        String source = "{ \"items\": null }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitTrimCorporateName() {
+        //given
+        String source = "{ \"items\": {\"corporate_name\": \"   ACME LIMITED \"} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", "ACME LIMITED"), actual);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRouteTest.java
@@ -1,0 +1,63 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+import uk.gov.companieshouse.reconciliation.model.Results;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@CamelSpringBootTest
+@SpringBootTest
+@DirtiesContext
+@TestPropertySource(locations = "classpath:application-stubbed.properties")
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchAlphaIndexRouteTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @Produce("direct:elasticsearch-alpha")
+    private ProducerTemplate producer;
+
+    @Mock
+    private ElasticsearchSlicedScrollIterator iterator;
+
+    @Test
+    void testTransformAlphaIndexResponseIntoResults() {
+        // given
+        when(iterator.hasNext()).thenReturn(true, false);
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), new HashMap<>());
+        hit.sourceRef(new BytesArray("{\"items\":{\"corporate_name_start\":\"ACME\",\"corporate_name_ending\":\" LIMITED\"}}"));
+        when(iterator.next()).thenReturn(hit);
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(iterator);
+
+        // when
+        Exchange actual = producer.send(exchange);
+
+        // then
+        assertTrue(actual.getIn().getBody(Results.class).contains(new ResultModel("12345678", "ACME LIMITED")));
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexRouteTest.java
@@ -47,7 +47,7 @@ public class ElasticsearchAlphaIndexRouteTest {
         // given
         when(iterator.hasNext()).thenReturn(true, false);
         SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), new HashMap<>());
-        hit.sourceRef(new BytesArray("{\"items\":{\"corporate_name_start\":\"ACME\",\"corporate_name_ending\":\" LIMITED\"}}"));
+        hit.sourceRef(new BytesArray("{\"items\":{\"corporate_name\":\"ACME LIMITED\"}}"));
         when(iterator.next()).thenReturn(hit);
         Exchange exchange = new DefaultExchange(context);
         exchange.getIn().setBody(iterator);

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexTransformerTest.java
@@ -1,22 +1,16 @@
 package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
 
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.text.Text;
-import org.elasticsearch.search.SearchHit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
-import uk.gov.companieshouse.reconciliation.model.ResultModel;
 import uk.gov.companieshouse.reconciliation.model.Results;
-import uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha.ElasticsearchAlphaIndexTransformer;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchTransformer;
 
-import java.util.Collections;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.times;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,136 +20,32 @@ public class ElasticsearchAlphaIndexTransformerTest {
     @Mock
     private ElasticsearchSlicedScrollIterator iterator;
 
+    @Mock
+    private ElasticsearchTransformer resultTransformer;
+
+    @Mock
+    private Results results;
+
+    @Mock
+    private ElasticsearchAlphaIndexResultMapper resultMapper;
+
     private ElasticsearchAlphaIndexTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new ElasticsearchAlphaIndexTransformer(10);
+        transformer = new ElasticsearchAlphaIndexTransformer(resultTransformer, resultMapper);
     }
 
     @Test
-    void testAggregateSearchHitsIntoResourceList() {
+    void testTransformSearchHits() {
         //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": {\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \" LIMITED\"} }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
+        when(resultTransformer.transform(any(), any(), any())).thenReturn(results);
 
         //when
         Results actual = transformer.transform(iterator, 1);
 
         //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "ACME LIMITED")));
-    }
-
-    @Test
-    void testAggregateSearchHitsReplaceNullValuesWithEmptyStrings() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": {\"corporate_name_start\": null, \"corporate_name_ending\": null} }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-    }
-
-    @Test
-    void testAggregateSearchHitsHandleEmptyItemsObject() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": {} }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-    }
-
-    @Test
-    void testAggregateSearchHitsHandleNullItems() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": null }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-    }
-
-    @Test
-    void testAggregateSearchHitsNoSpaceBetweenNameStartAndNameEnding() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": {\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"LIMITED\"} }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "ACME LIMITED")));
-    }
-
-    @Test
-    void testAggregateSearchHitsNameEndingAbsent() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": {\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"\"} }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "ACME")));
-    }
-
-    @Test
-    void testAggregateSearchHitsNameStartAbsent() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": {\"corporate_name_start\": \"\", \"corporate_name_ending\": \" LIMITED\"} }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "LIMITED")));
+        assertSame(results, actual);
+        verify(resultTransformer).transform(iterator, 1, resultMapper);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexTransformerTest.java
@@ -1,0 +1,161 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+import uk.gov.companieshouse.reconciliation.model.Results;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.alpha.ElasticsearchAlphaIndexTransformer;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchAlphaIndexTransformerTest {
+
+    @Mock
+    private ElasticsearchSlicedScrollIterator iterator;
+
+    private ElasticsearchAlphaIndexTransformer transformer;
+
+    @BeforeEach
+    void setUp() {
+        transformer = new ElasticsearchAlphaIndexTransformer(10);
+    }
+
+    @Test
+    void testAggregateSearchHitsIntoResourceList() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": {\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \" LIMITED\"} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "ACME LIMITED")));
+    }
+
+    @Test
+    void testAggregateSearchHitsReplaceNullValuesWithEmptyStrings() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": {\"corporate_name_start\": null, \"corporate_name_ending\": null} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "")));
+    }
+
+    @Test
+    void testAggregateSearchHitsHandleEmptyItemsObject() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": {} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "")));
+    }
+
+    @Test
+    void testAggregateSearchHitsHandleNullItems() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": null }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "")));
+    }
+
+    @Test
+    void testAggregateSearchHitsNoSpaceBetweenNameStartAndNameEnding() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": {\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"LIMITED\"} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "ACME LIMITED")));
+    }
+
+    @Test
+    void testAggregateSearchHitsNameEndingAbsent() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": {\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"\"} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "ACME")));
+    }
+
+    @Test
+    void testAggregateSearchHitsNameStartAbsent() {
+        //given
+        when(iterator.hasNext()).thenReturn(true, false);
+        String source = "{ \"items\": {\"corporate_name_start\": \"\", \"corporate_name_ending\": \" LIMITED\"} }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+        when(iterator.next()).thenReturn(hit);
+
+        //when
+        Results actual = transformer.transform(iterator, 1);
+
+        //then
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+        assertTrue(actual.contains(new ResultModel("12345678", "LIMITED")));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexResultMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexResultMapperTest.java
@@ -1,0 +1,132 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ElasticsearchPrimaryIndexResultMapperTest {
+
+    private ElasticsearchPrimaryIndexResultMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ElasticsearchPrimaryIndexResultMapper();
+    }
+
+    @Test
+    void testMapSearchHitIntoResultModel() {
+        //given
+        String source = "{ \"items\": [{\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \" LIMITED\"}] }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", "ACME LIMITED"), actual);
+    }
+
+    @Test
+    void testMapSearchHitWithoutSourceFields() {
+        //given
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+
+        //when
+        ResultModel actual = mapper.mapExcludingSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitReplaceNullValuesWithEmptyStrings() {
+        //given
+        String source = "{ \"items\": [{\"corporate_name_start\": null, \"corporate_name_ending\": null}] }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitHandleEmptyItemsArray() {
+        //given
+        String source = "{ \"items\": [] }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitHandleNullItems() {
+        //given
+        String source = "{ \"items\": null }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", ""), actual);
+    }
+
+    @Test
+    void testMapSearchHitNoSpaceBetweenNameStartAndNameEnding() {
+        //given
+        String source = "{ \"items\": [{\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"LIMITED\"}] }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", "ACME LIMITED"), actual);
+    }
+
+    @Test
+    void testMapSearchHitNameEndingAbsent() {
+        //given
+        String source = "{ \"items\": [{\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"\"}] }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", "ACME"), actual);
+    }
+
+    @Test
+    void testMapSearchHitNameStartAbsent() {
+        //given
+        String source = "{ \"items\": [{\"corporate_name_start\": \"\", \"corporate_name_ending\": \" LIMITED\"}] }";
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
+        hit.sourceRef(new BytesArray(source));
+
+        //when
+        ResultModel actual = mapper.mapWithSourceFields(hit);
+
+        //then
+        assertEquals(new ResultModel("12345678", "LIMITED"), actual);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexRouteTest.java
@@ -1,0 +1,62 @@
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.support.DefaultExchange;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.SearchHit;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
+import uk.gov.companieshouse.reconciliation.model.ResultModel;
+import uk.gov.companieshouse.reconciliation.model.Results;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@CamelSpringBootTest
+@SpringBootTest
+@DirtiesContext
+@TestPropertySource(locations = "classpath:application-stubbed.properties")
+public class ElasticsearchPrimaryIndexRouteTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @Produce("direct:elasticsearch-primary")
+    private ProducerTemplate producer;
+
+    @Mock
+    private ElasticsearchSlicedScrollIterator iterator;
+
+    @Test
+    void testTransformAlphaIndexResponseIntoResults() {
+        // given
+        when(iterator.hasNext()).thenReturn(true, false);
+        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), new HashMap<>());
+        hit.sourceRef(new BytesArray("{\"items\":[{\"corporate_name_start\":\"ACME\",\"corporate_name_ending\":\" LIMITED\"}]}"));
+        when(iterator.next()).thenReturn(hit);
+        Exchange exchange = new DefaultExchange(context);
+        exchange.getIn().setBody(iterator);
+
+        // when
+        Exchange actual = producer.send(exchange);
+
+        // then
+        assertTrue(actual.getIn().getBody(Results.class).contains(new ResultModel("12345678", "ACME LIMITED")));
+        verify(iterator, times(2)).hasNext();
+        verify(iterator, times(1)).next();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.reconciliation.service.elasticsearch;
+package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.text.Text;
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
 import uk.gov.companieshouse.reconciliation.model.ResultModel;
 import uk.gov.companieshouse.reconciliation.model.Results;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.primary.ElasticsearchPrimaryIndexTransformer;
 
 import java.util.Collections;
 
@@ -20,16 +21,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class ElasticsearchTransformerTest {
+public class ElasticsearchPrimaryIndexTransformerTest {
 
     @Mock
     private ElasticsearchSlicedScrollIterator iterator;
 
-    private ElasticsearchTransformer transformer;
+    private ElasticsearchPrimaryIndexTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new ElasticsearchTransformer();
+        transformer = new ElasticsearchPrimaryIndexTransformer(10);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/primary/ElasticsearchPrimaryIndexTransformerTest.java
@@ -1,23 +1,16 @@
 package uk.gov.companieshouse.reconciliation.service.elasticsearch.primary;
 
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.text.Text;
-import org.elasticsearch.search.SearchHit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscroll.client.ElasticsearchSlicedScrollIterator;
-import uk.gov.companieshouse.reconciliation.model.ResultModel;
 import uk.gov.companieshouse.reconciliation.model.Results;
-import uk.gov.companieshouse.reconciliation.service.elasticsearch.primary.ElasticsearchPrimaryIndexTransformer;
+import uk.gov.companieshouse.reconciliation.service.elasticsearch.ElasticsearchTransformer;
 
-import java.util.Collections;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,153 +19,31 @@ public class ElasticsearchPrimaryIndexTransformerTest {
     @Mock
     private ElasticsearchSlicedScrollIterator iterator;
 
+    @Mock
+    private ElasticsearchTransformer resultTransformer;
+
+    @Mock
+    private Results results;
+
+    @Mock
+    private ElasticsearchPrimaryIndexResultMapper searchHitMapper;
+
     private ElasticsearchPrimaryIndexTransformer transformer;
 
     @BeforeEach
     void setUp() {
-        transformer = new ElasticsearchPrimaryIndexTransformer(10);
+        transformer = new ElasticsearchPrimaryIndexTransformer(resultTransformer, searchHitMapper);
     }
 
     @Test
-    void testAggregateSearchHitsIntoResourceList() {
+    void testTransformSearchHits() {
         //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": [{\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \" LIMITED\"}] }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
+        when(resultTransformer.transform(any(), any(), any())).thenReturn(results);
 
         //when
         Results actual = transformer.transform(iterator, 1);
 
         //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "ACME LIMITED")));
-    }
-
-    @Test
-    void testAggregateSearchHitsWithoutSourceFields() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-    }
-
-    @Test
-    void testAggregateSearchHitsReplaceNullValuesWithEmptyStrings() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": [{\"corporate_name_start\": null, \"corporate_name_ending\": null}] }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-
-    }
-
-    @Test
-    void testAggregateSearchHitsHandleEmptyItemsArray() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": [] }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-    }
-
-    @Test
-    void testAggregateSearchHitsHandleNullItems() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": null }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "")));
-    }
-
-    @Test
-    void testAggregateSearchHitsNoSpaceBetweenNameStartAndNameEnding() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": [{\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"LIMITED\"}] }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "ACME LIMITED")));
-    }
-
-    @Test
-    void testAggregateSearchHitsNameEndingAbsent() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": [{\"corporate_name_start\": \"ACME\", \"corporate_name_ending\": \"\"}] }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "ACME")));
-    }
-
-    @Test
-    void testAggregateSearchHitsNameStartAbsent() {
-        //given
-        when(iterator.hasNext()).thenReturn(true, false);
-        String source = "{ \"items\": [{\"corporate_name_start\": \"\", \"corporate_name_ending\": \" LIMITED\"}] }";
-        SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
-        hit.sourceRef(new BytesArray(source));
-        when(iterator.next()).thenReturn(hit);
-
-        //when
-        Results actual = transformer.transform(iterator, 1);
-
-        //then
-        verify(iterator, times(2)).hasNext();
-        verify(iterator, times(1)).next();
-        assertTrue(actual.contains(new ResultModel("12345678", "LIMITED")));
+        assertSame(results, actual);
     }
 }

--- a/src/test/resources/application-stubbed.properties
+++ b/src/test/resources/application-stubbed.properties
@@ -41,6 +41,7 @@ endpoint.company_collection_mongo_primary.cron.tab=direct:company_collection_mon
 endpoint.company_collection_mongo_alpha.cron.tab=direct:company_collection_mongo_alpha_trigger
 endpoint.dsq_officer_collection.cron.tab=direct:dsq_officer_trigger
 endpoint.company_name_mongo_primary.cron.tab=direct:company_name_mongo_primary_trigger
+endpoint.company_name_mongo_alpha.cron.tab=direct:company_name_mongo_alpha_trigger
 
 # Functions
 function.name.compare_count=mock:compare_count


### PR DESCRIPTION
* Create CompanyNameCompareMongoDBAlphaSearch trigger route
* Change alpha.json to include corporate_name_start and corporate_name_ending
* Seperate transformation logic for primary and alpha index
* Add new transformer header to each elasticsearch comparator trigger
* RecordType header name used by CompareResultsRoute changed to RecordKey.
* Comparison header added to company name comparators.

[BI-7525](https://companieshouse.atlassian.net/browse/BI-7525)