### PR TITLE
BI-7527 - Company status alpha index comparator

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyStatusCompareMongoDBAlphaSearch.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/company/CompanyStatusCompareMongoDBAlphaSearch.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.reconciliation.company;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.aws2.s3.AWS2S3Constants;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CompanyStatusCompareMongoDBAlphaSearch extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+        from("{{endpoint.company_status_mongo_alpha.cron.tab}}")
+                .setHeader("Src").constant("{{endpoint.mongodb.wrapper.company_profile.collection}}")
+                .setHeader("SrcDescription").constant("MongoDB - Company Profile")
+                .setHeader("Target").constant("{{endpoint.elasticsearch.collection}}")
+                .setHeader("TargetDescription").constant("Alpha Index")
+                .setHeader("ElasticsearchEndpoint").constant("{{endpoint.elasticsearch.alpha}}")
+                .setHeader("ElasticsearchQuery").constant("{{query.elasticsearch.alpha.company}}")
+                .setHeader("ElasticsearchCacheKey").constant("{{endpoint.elasticsearch.alpha.cache.key}}")
+                .setHeader("ElasticsearchTransformer").constant("{{transformer.elasticsearch.alpha}}")
+                .setHeader("RecordKey").constant("Company Number")
+                .setHeader("Comparison").constant("company statuses")
+                .setHeader("Destination").constant("{{endpoint.elasticsearch.output}}")
+                .setHeader("ResultsTransformer").constant("{{function.mapper.company_statuses}}")
+                .setHeader("Upload", constant("{{endpoint.s3.upload}}"))
+                .setHeader("Presign", constant("{{endpoint.s3presigner.download}}"))
+                .setHeader(AWS2S3Constants.KEY, simple("company/results_status_alpha_mongo_${date:now:yyyyMMdd}T${date:now:hhmmss}.csv"))
+                .setHeader(AWS2S3Constants.DOWNLOAD_LINK_EXPIRATION_TIME, constant("{{aws.expiry}}"))
+                .to("{{function.name.compare_results}}");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendElasticsearchEmailRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendElasticsearchEmailRoute.java
@@ -14,7 +14,7 @@ public class SendElasticsearchEmailRoute extends RouteBuilder {
     public void configure() throws Exception {
         from("direct:send-elasticsearch-email")
                 .aggregate(constant(true), new EmailAggregationStrategy())
-                .completionSize(5)
+                .completionSize(6)
                 .setHeader("CompletionDate", simple("${date:now:dd MMMM yyyy}"))
                 .setHeader("EmailSubject", simple("Elasticsearch comparisons (${header.CompletionDate})"))
                 .to("{{endpoint.kafka.sender}}");

--- a/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapper.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapper.java
@@ -14,7 +14,8 @@ public class ElasticsearchAlphaIndexResultMapper implements ElasticsearchResultM
     @Override
     public ResultModel mapWithSourceFields(SearchHit hit) {
         String corporateName = getSourceField(hit, "corporate_name");
-        return new ResultModel(hit.getId(), corporateName);
+        String companyStatus = getSourceField(hit, "company_status");
+        return new ResultModel(hit.getId(), corporateName, companyStatus);
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,6 +48,7 @@ endpoint.dsq_officer_collection.cron.tab=cron:dsq_officer_collection?schedule=${
 endpoint.company_name_mongo_primary.cron.tab=cron:company_name_mongo_primary?schedule=${COMPANY_NAME_MONGO_PRIMARY_CRONTAB}
 endpoint.company_name_mongo_alpha.cron.tab=cron:company_name_mongo_alpha?schedule=${COMPANY_NAME_MONGO_ALPHA_CRONTAB}
 endpoint.company_status_mongo_primary.cron.tab=cron:company_status_mongo_primary?schedule=${COMPANY_STATUS_MONGO_PRIMARY_CRONTAB}
+endpoint.company_status_mongo_alpha.cron.tab=cron:company_status_mongo_alpha?schedule=${COMPANY_STATUS_MONGO_ALPHA_CRONTAB}
 
 # Functions
 function.name.compare_count=direct:compare_count

--- a/src/main/resources/elasticsearch/alpha.json
+++ b/src/main/resources/elasticsearch/alpha.json
@@ -4,7 +4,8 @@
   },
   "_source": {
     "includes": [
-      "items.corporate_name"
+      "items.corporate_name",
+      "items.company_status"
     ]
   }
 }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyStatusCompareMongoDBAlphaSearchTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/company/CompanyStatusCompareMongoDBAlphaSearchTest.java
@@ -1,0 +1,55 @@
+package uk.gov.companieshouse.reconciliation.company;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.aws2.s3.AWS2S3Constants;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@CamelSpringBootTest
+@SpringBootTest
+@DirtiesContext
+@TestPropertySource(locations = "classpath:application-stubbed.properties")
+public class CompanyStatusCompareMongoDBAlphaSearchTest {
+
+    @Autowired
+    private CamelContext context;
+
+    @EndpointInject("mock:compare_results")
+    private MockEndpoint target;
+
+    @Produce("direct:company_status_mongo_alpha_trigger")
+    private ProducerTemplate producerTemplate;
+
+    @BeforeEach
+    void setUp() {
+        target.reset();
+    }
+
+    @Test
+    void testSetHeadersAndProduceMessage() throws InterruptedException {
+        target.expectedHeaderReceived("Src", "mock:mongoCompanyProfileCollection");
+        target.expectedHeaderReceived("SrcDescription", "MongoDB - Company Profile");
+        target.expectedHeaderReceived("Target", "mock:elasticsearch-collection");
+        target.expectedHeaderReceived("TargetDescription", "Alpha Index");
+        target.expectedHeaderReceived("ElasticsearchEndpoint", "mock:elasticsearch-alpha-stub");
+        target.expectedHeaderReceived("ElasticsearchCacheKey", "elasticsearchAlpha");
+        target.expectedHeaderReceived("ElasticsearchQuery", "alpha-test");
+        target.expectedHeaderReceived("RecordKey", "Company Number");
+        target.expectedHeaderReceived("Comparison", "company statuses");
+        target.expectedHeaderReceived("Destination", "mock:elasticsearch");
+        target.expectedHeaderReceived("Upload", "mock:s3_bucket_destination");
+        target.expectedHeaderReceived("Presign", "mock:s3_download_link");
+        target.expectedHeaderReceived(AWS2S3Constants.DOWNLOAD_LINK_EXPIRATION_TIME, 2000L);
+        producerTemplate.sendBody(0);
+        MockEndpoint.assertIsSatisfied(context);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/reconciliation/email/SendElasticsearchEmailRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/email/SendElasticsearchEmailRouteTest.java
@@ -50,7 +50,7 @@ public class SendElasticsearchEmailRouteTest {
                 interceptSendToEndpoint("mock:kafka-endpoint")
                         .process(exchange -> {
                             ResourceLinksWrapper downloadsList = exchange.getIn().getHeader("ResourceLinks", ResourceLinksWrapper.class);
-                            assertEquals(5, downloadsList.getDownloadLinkList().size());
+                            assertEquals(6, downloadsList.getDownloadLinkList().size());
                         });
             }
         });
@@ -76,12 +76,17 @@ public class SendElasticsearchEmailRouteTest {
                 .withHeader("ResourceLinkReference", "Compare Status Primary Mongo Link")
                 .build();
 
+        Exchange sixthExchange = ExchangeBuilder.anExchange(context)
+                .withHeader("ResourceLinkReference", "Compare Status Alpha Mongo Link")
+                .build();
+
         kafkaEndpoint.expectedMessageCount(1);
         producerTemplate.send(firstExchange);
         producerTemplate.send(secondExchange);
         producerTemplate.send(thirdExchange);
         producerTemplate.send(fourthExchange);
         producerTemplate.send(fifthExchange);
+        producerTemplate.send(sixthExchange);
 
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/email/SendElasticsearchEmailRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/email/SendElasticsearchEmailRouteTest.java
@@ -76,7 +76,7 @@ public class SendElasticsearchEmailRouteTest {
                 .withHeader("ResourceLinkReference", "Compare Status Primary Mongo Link")
                 .build();
 
-        Exchange sixthExchange = ExchangeBuilder.anExchange(context)
+        Exchange compareStatusAlphaMongoExchange = ExchangeBuilder.anExchange(context)
                 .withHeader("ResourceLinkReference", "Compare Status Alpha Mongo Link")
                 .build();
 
@@ -86,7 +86,7 @@ public class SendElasticsearchEmailRouteTest {
         producerTemplate.send(thirdExchange);
         producerTemplate.send(fourthExchange);
         producerTemplate.send(fifthExchange);
-        producerTemplate.send(sixthExchange);
+        producerTemplate.send(compareStatusAlphaMongoExchange);
 
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/service/elasticsearch/alpha/ElasticsearchAlphaIndexResultMapperTest.java
@@ -23,7 +23,7 @@ public class ElasticsearchAlphaIndexResultMapperTest {
     @Test
     void testMapSearchHitToResultModel() {
         //given
-        String source = "{ \"items\": {\"corporate_name\": \"ACME LIMITED\"} }";
+        String source = "{ \"items\": {\"corporate_name\": \"ACME LIMITED\", \"company_status\": \"active\"} }";
         SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
         hit.sourceRef(new BytesArray(source));
 
@@ -31,7 +31,7 @@ public class ElasticsearchAlphaIndexResultMapperTest {
         ResultModel actual = mapper.mapWithSourceFields(hit);
 
         //then
-        assertEquals(new ResultModel("12345678", "ACME LIMITED"), actual);
+        assertEquals(new ResultModel("12345678", "ACME LIMITED", "active"), actual);
     }
 
     @Test
@@ -43,13 +43,13 @@ public class ElasticsearchAlphaIndexResultMapperTest {
         ResultModel actual = mapper.mapExcludingSourceFields(hit);
 
         //then
-        assertEquals(new ResultModel("12345678", ""), actual);
+        assertEquals(new ResultModel("12345678", "", ""), actual);
     }
 
     @Test
     void testMapSearchHitReplaceNullValuesWithEmptyStrings() {
         //given
-        String source = "{ \"items\": {\"corporate_name\": null} }";
+        String source = "{ \"items\": {\"corporate_name\": null, \"company_status\": null} }";
         SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
         hit.sourceRef(new BytesArray(source));
 
@@ -57,7 +57,7 @@ public class ElasticsearchAlphaIndexResultMapperTest {
         ResultModel actual = mapper.mapWithSourceFields(hit);
 
         //then
-        assertEquals(new ResultModel("12345678", ""), actual);
+        assertEquals(new ResultModel("12345678", "", ""), actual);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ElasticsearchAlphaIndexResultMapperTest {
         ResultModel actual = mapper.mapWithSourceFields(hit);
 
         //then
-        assertEquals(new ResultModel("12345678", ""), actual);
+        assertEquals(new ResultModel("12345678", "", ""), actual);
     }
 
     @Test
@@ -85,13 +85,13 @@ public class ElasticsearchAlphaIndexResultMapperTest {
         ResultModel actual = mapper.mapWithSourceFields(hit);
 
         //then
-        assertEquals(new ResultModel("12345678", ""), actual);
+        assertEquals(new ResultModel("12345678", "", ""), actual);
     }
 
     @Test
-    void testMapSearchHitTrimCorporateName() {
+    void testMapSearchHitTrimSourceFields() {
         //given
-        String source = "{ \"items\": {\"corporate_name\": \"   ACME LIMITED \"} }";
+        String source = "{ \"items\": {\"corporate_name\": \"   ACME LIMITED \", \"company_status\": \"  active   \"} }";
         SearchHit hit = new SearchHit(123, "12345678", new Text("{}"), Collections.emptyMap());
         hit.sourceRef(new BytesArray(source));
 
@@ -99,6 +99,6 @@ public class ElasticsearchAlphaIndexResultMapperTest {
         ResultModel actual = mapper.mapWithSourceFields(hit);
 
         //then
-        assertEquals(new ResultModel("12345678", "ACME LIMITED"), actual);
+        assertEquals(new ResultModel("12345678", "ACME LIMITED", "active"), actual);
     }
 }

--- a/src/test/resources/application-stubbed.properties
+++ b/src/test/resources/application-stubbed.properties
@@ -43,6 +43,7 @@ endpoint.dsq_officer_collection.cron.tab=direct:dsq_officer_trigger
 endpoint.company_name_mongo_primary.cron.tab=direct:company_name_mongo_primary_trigger
 endpoint.company_name_mongo_alpha.cron.tab=direct:company_name_mongo_alpha_trigger
 endpoint.company_status_mongo_primary.cron.tab=direct:company_status_mongo_primary_trigger
+endpoint.company_status_mongo_alpha.cron.tab=direct:company_status_mongo_alpha_trigger
 
 # Functions
 function.name.compare_count=mock:compare_count


### PR DESCRIPTION
- Add trigger route
- Include items.company-status in fields returned by Elasticsearch alpha index
- Update Elasticsearch aggregation pipeline

[BI-7527](https://companieshouse.atlassian.net/browse/BI-7527)