### PR TITLE
Bug/bi 8424 exception when no comparators enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,13 @@
 Each comparator belongs to a comparison group. After all comparators in the comparison group have run, 
 results produced by each comparator will be published to S3 and a message will be sent to a Kafka topic.
 
-The following tables contain toggles (for enabling/disabling each comparator) 
-and timer delays (after application startup for each comparator).
+The following tables contain toggles (for enabling/disabling each comparator) and timer delays (after application
+startup for each comparator).
 
+*Note: the application will only start when one or more comparison group toggles have been enabled; when no comparison
+group toggles have been enabled an error message will be logged i.e.*
+
+> No aggregation group models enabled; must be at least one
 
 ### Company Profile Comparisons - MongoDB-Oracle
 

--- a/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationGroupConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationGroupConfiguration.java
@@ -4,7 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +28,6 @@ aggregation-group.&lt;key2&gt;.size = n2
      * @return map
      */
     @Bean
-    @Validated
     @ConfigurationProperties(prefix = "aggregation-group")
     public Map<String, AggregationGroupModel> aggregationGroupModelMap() {
         return new HashMap<>();

--- a/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationGroupModel.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationGroupModel.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.reconciliation.config;
 
+import org.springframework.validation.annotation.Validated;
+
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
@@ -10,6 +12,7 @@ import java.util.stream.Collectors;
  *
  * Note that this model also defines a size that represents the number of aggregation models in this model.
  */
+@Validated
 public class AggregationGroupModel {
 
     @NotEmpty

--- a/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationHandler.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationHandler.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.reconciliation.config;
 
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -7,6 +10,7 @@ import java.util.stream.Collectors;
 /**
  * Supplies {@link AggregationGroupModel}'s for given comparison group names.
  */
+@Validated
 public class AggregationHandler {
 
     @NotNull
@@ -38,6 +42,7 @@ public class AggregationHandler {
      *
      * @return size representing the number of enabled aggregation group models
      */
+    @Min(value = 1, message = "No aggregation group models enabled; must be at least one")
     public int getEnabledAggregationGroupModelsSize() {
         return aggregationGroupModel.values().stream()
                 .filter(aggregationGroupModel -> aggregationGroupModel.getEnabledAggregationModelsSize() > 0)

--- a/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationHandlerConfiguration.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationHandlerConfiguration.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.validation.annotation.Validated;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -37,7 +36,6 @@ public class AggregationHandlerConfiguration {
      * @return values defined in aggregation-group.properties that represents valid comparison groups.
      */
     @Bean
-    @Validated
     public AggregationHandler aggregationHandler() {
         return new AggregationHandler(aggregationGroupModels.values()
                 .stream()

--- a/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationModel.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/config/AggregationModel.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.reconciliation.config;
 
+import org.springframework.validation.annotation.Validated;
 import uk.gov.companieshouse.reconciliation.model.ResourceLink;
 
 import javax.validation.constraints.NotNull;
@@ -8,6 +9,7 @@ import javax.validation.constraints.NotNull;
  * Aggregation model that defines a rank that can be used to order {@link ResourceLink}.
  * Also contains a boolean field to represent whether the model is enabled or not.
  */
+@Validated
 public class AggregationModel {
 
     @NotNull


### PR DESCRIPTION
- Ensure that when no comparisons are enabled that the application does not start and an error is output in the log.
- Update `README` with detail of application behaviour when no comparison groups are enabled.
- Add bean validation to `AggregationHandler.getEnabledAggregationGroupModesSize()` to ensure that at least 1 model is enabled.
- Use `@Validated` annotation at the class level to ensure that the `AggregationHandler` Spring bean is correctly validated

Fixes: [BI-8424: Application throws an unexpected IllegalStateException if no comparators are enabled](https://companieshouse.atlassian.net/browse/BI-8424)