### PR TITLE
Use raw AWS access key and secret access key

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,8 +28,8 @@ query.elasticsearch.primary.company=resource:classpath:/elasticsearch/primary_co
 endpoint.elasticsearch.log_indices=${ENDPOINT_ELASTICSEARCH_LOG_INDICES:100000}
 
 # AWS config
-endpoint.s3.upload=aws2-s3://${RESULTS_BUCKET}?accessKey=${AWS_ACCESS_KEY_ID}&secretKey=${AWS_SECRET_ACCESS_KEY}&region=${AWS_REGION}
-endpoint.s3presigner.download=aws2-s3://${RESULTS_BUCKET}?operation=createDownloadLink&accessKey=${AWS_ACCESS_KEY_ID}&secretKey=${AWS_SECRET_ACCESS_KEY}&region=${AWS_REGION}
+endpoint.s3.upload=aws2-s3://${RESULTS_BUCKET}?accessKey=RAW(${AWS_ACCESS_KEY_ID})&secretKey=RAW(${AWS_SECRET_ACCESS_KEY})&region=${AWS_REGION}
+endpoint.s3presigner.download=aws2-s3://${RESULTS_BUCKET}?operation=createDownloadLink&accessKey=RAW(${AWS_ACCESS_KEY_ID})&secretKey=RAW(${AWS_SECRET_ACCESS_KEY})&region=${AWS_REGION}
 aws.expiry=${RESULTS_EXPIRY_TIME_IN_MILLIS}
 
 # Kafka config


### PR DESCRIPTION
* Fixes an issue causing special characters (e.g. '+') not being encoded properly.