### PR TITLE
BI-8471 Remove SrcList, TargetList headers after use

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRoute.java
@@ -55,6 +55,8 @@ public class CompareCollectionRoute extends RouteBuilder {
                     return prev;
                 })
                 .bean(CompareCollectionTransformer.class)
+                .removeHeader("SrcList")
+                .removeHeader("TargetList")
                 .marshal().csv()
                 .setHeader("ResourceLinkDescription", simple("Completed ${header.ComparisonDescription}."))
                 .log("${header.ResourceLinkDescription}")

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRoute.java
@@ -52,6 +52,8 @@ public class CompareResultsRoute extends RouteBuilder {
                     return oldExchange;
                 })
                 .toD("${header.ResultsTransformer}")
+                .removeHeader("SrcList")
+                .removeHeader("TargetList")
                 .marshal().csv()
                 .setHeader("ResourceLinkDescription").simple("Completed ${header.ComparisonDescription}.")
                 .log("Compare results succeeded: ${header.ResourceLinkDescription}")

--- a/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRouteTest.java
@@ -19,6 +19,8 @@ import uk.gov.companieshouse.reconciliation.function.compare_collection.entity.R
 
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 @CamelSpringBootTest
 @SpringBootTest
 @DirtiesContext
@@ -52,7 +54,10 @@ public class CompareCollectionRouteTest {
         mockFruitTreeEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(new ResourceList(Arrays.asList("apple", "strawberry"), "Fruit Tree")));
         mockFruitBasketEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(new ResourceList(Arrays.asList("apple", "orange", "pineapple"), "Fruit Basket")));
         mockCompareResult.expectedBodyReceived().constant("Fruit,Exclusive To\r\nstrawberry,Fruit Tree\r\norange,Fruit Basket\r\npineapple,Fruit Basket\r\n".getBytes());
-        producerTemplate.send(createExchange());
+        Exchange msg = createExchange();
+        producerTemplate.send(msg);
+        assertNull(msg.getIn().getHeader("SrcList"));
+        assertNull(msg.getIn().getHeader("TargetList"));
         MockEndpoint.assertIsSatisfied(context);
     }
 
@@ -61,7 +66,10 @@ public class CompareCollectionRouteTest {
         mockFruitTreeEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(new ResourceList(Arrays.asList("apple", null), "Fruit Tree")));
         mockFruitBasketEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(new ResourceList(Arrays.asList("apple", "orange", "pineapple"), "Fruit Basket")));
         mockCompareResult.expectedBodyReceived().constant("Fruit,Exclusive To\r\n,Fruit Tree\r\norange,Fruit Basket\r\npineapple,Fruit Basket\r\n".getBytes());
-        producerTemplate.send(createExchange());
+        Exchange msg = createExchange();
+        producerTemplate.send(msg);
+        assertNull(msg.getIn().getHeader("SrcList"));
+        assertNull(msg.getIn().getHeader("TargetList"));
         MockEndpoint.assertIsSatisfied(context);
     }
 


### PR DESCRIPTION
* Resource lists no longer needed after transformation.
* Raised due to high memory usage on staging envt.