### PR TITLE
BI-8651 Add support for single slice

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchScrollingSearchClient.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchScrollingSearchClient.java
@@ -59,12 +59,14 @@ public class ElasticsearchScrollingSearchClient implements AutoCloseable {
         SearchModule module = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
         XContentParser parser = JsonXContent.jsonXContent.createParser(new NamedXContentRegistry(module.getNamedXContents()), query);
         SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.fromXContent(parser);
-        searchRequest.scroll(new TimeValue(timeout, TimeUnit.SECONDS))
+        SearchSourceBuilder scrollRequestSource = searchRequest.scroll(new TimeValue(timeout, TimeUnit.SECONDS))
                 .source()
                 .query(searchSourceBuilder.query())
-                .slice(new SliceBuilder(sliceField, sliceId, noOfSlices))
                 .fetchSource(searchSourceBuilder.fetchSource())
                 .size(size);
+        if(noOfSlices > 1) {
+            scrollRequestSource.slice(new SliceBuilder(sliceField, sliceId, noOfSlices));
+        }
         return client.search(searchRequest);
     }
 

--- a/src/main/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchSlicedScrollValidator.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchSlicedScrollValidator.java
@@ -6,6 +6,6 @@ package uk.gov.companieshouse.reconciliation.component.elasticsearch.slicedscrol
 public class ElasticsearchSlicedScrollValidator {
 
     public boolean validateSliceConfiguration(int sliceId, int noOfSlices) {
-        return sliceId >= 0 && noOfSlices > 1 && sliceId < noOfSlices;
+        return (sliceId == 0 && noOfSlices == 1) || (sliceId >= 0 && noOfSlices > 1 && sliceId < noOfSlices);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchSlicedScrollValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/component/elasticsearch/slicedscroll/client/ElasticsearchSlicedScrollValidatorTest.java
@@ -16,9 +16,18 @@ public class ElasticsearchSlicedScrollValidatorTest {
     }
 
     @Test
-    void testReturnTrueIfArgsValid() {
+    void testReturnTrueIfMultipleSlicedScrollRequestValid() {
         //when
         boolean actual = validator.validateSliceConfiguration(1, 2);
+
+        //then
+        assertTrue(actual);
+    }
+
+    @Test
+    void testReturnTrueIfSingleSlicedScrollRequestValid() {
+        //when
+        boolean actual = validator.validateSliceConfiguration(0, 1);
 
         //then
         assertTrue(actual);
@@ -43,9 +52,18 @@ public class ElasticsearchSlicedScrollValidatorTest {
     }
 
     @Test
-    void testReturnFalseIfNumberOfSlicesLessThanTwo() {
+    void testReturnFalseIfNumberOfSlicesLessThanOne() {
         //when
-        boolean actual = validator.validateSliceConfiguration(0, 1);
+        boolean actual = validator.validateSliceConfiguration(0, 0);
+
+        //then
+        assertFalse(actual);
+    }
+
+    @Test
+    void testReturnFalseIfSliceIdNonzeroAndNumberOfSlicesIsOne() {
+        //when
+        boolean actual = validator.validateSliceConfiguration(1, 1);
 
         //then
         assertFalse(actual);


### PR DESCRIPTION
* Set slice filter only if number of slices is greater than 1.
* Required as search API errors if max field is less than 2.

Resolves:
[BI-8651](https://companieshouse.atlassian.net/browse/BI-8651)