### PR TITLE
BI-8872 Remove full stops from resource link descriptions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRoute.java
@@ -28,7 +28,7 @@ public class CompareCollectionRoute extends RouteBuilder {
     public void configure() throws Exception {
         from("direct:compare_collection")
                 .onException(ComparisonFailedException.class)
-                    .setHeader("ResourceLinkDescription", simple("Failed to perform ${header.ComparisonDescription}."))
+                    .setHeader("ResourceLinkDescription", simple("Failed to perform ${header.ComparisonDescription}"))
                     .setHeader("Failed").constant(true)
                     .log(LoggingLevel.ERROR, "${header.ResourceLinkDescription}")
                     .handled(true)
@@ -58,7 +58,7 @@ public class CompareCollectionRoute extends RouteBuilder {
                 .removeHeader("SrcList")
                 .removeHeader("TargetList")
                 .marshal().csv()
-                .setHeader("ResourceLinkDescription", simple("Completed ${header.ComparisonDescription}."))
+                .setHeader("ResourceLinkDescription", simple("Completed ${header.ComparisonDescription}"))
                 .log("${header.ResourceLinkDescription}")
                 .toD("${header.Destination}");
     }

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_count/CompareCountRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_count/CompareCountRoute.java
@@ -46,7 +46,7 @@ public class CompareCountRoute extends RetryableRoute {
         super.configure();
         from("direct:compare_count")
                 .onException(SQLException.class, MongoException.class)
-                    .setHeader("ResourceLinkDescription", simple("Failed to perform ${header.ComparisonDescription}."))
+                    .setHeader("ResourceLinkDescription", simple("Failed to perform ${header.ComparisonDescription}"))
                     .setHeader("Failed").constant(true)
                     .log(LoggingLevel.ERROR, "Compare count failed: ${header.ResourceLinkDescription}")
                     .handled(true)
@@ -76,11 +76,11 @@ public class CompareCountRoute extends RetryableRoute {
                 .marshal().csv()
                 .choice()
                     .when(header("Weight").isLessThan(0))
-                        .setHeader("ResourceLinkDescription", simple("${header.TargetName} has ${header.WeightAbs} more ${header.Comparison} than ${header.SrcName}."))
+                        .setHeader("ResourceLinkDescription", simple("${header.TargetName} has ${header.WeightAbs} more ${header.Comparison} than ${header.SrcName}"))
                     .when(header("Weight").isGreaterThan(0))
-                        .setHeader("ResourceLinkDescription", simple("${header.SrcName} has ${header.WeightAbs} more ${header.Comparison} than ${header.TargetName}."))
+                        .setHeader("ResourceLinkDescription", simple("${header.SrcName} has ${header.WeightAbs} more ${header.Comparison} than ${header.TargetName}"))
                     .otherwise()
-                        .setHeader("ResourceLinkDescription", simple("${header.SrcName} and ${header.TargetName} contain the same number of ${header.Comparison}."))
+                        .setHeader("ResourceLinkDescription", simple("${header.SrcName} and ${header.TargetName} contain the same number of ${header.Comparison}"))
                 .end()
                 .log("Completed ${header.ComparisonDescription}.")
                 .toD("${header.Destination}");

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRoute.java
@@ -27,7 +27,7 @@ public class CompareResultsRoute extends RouteBuilder {
     public void configure() throws Exception {
         from("direct:compare_results")
                 .onException(ComparisonFailedException.class)
-                    .setHeader("ResourceLinkDescription").simple("Failed to perform ${header.ComparisonDescription}.")
+                    .setHeader("ResourceLinkDescription").simple("Failed to perform ${header.ComparisonDescription}")
                     .setHeader("Failed").constant(true)
                     .log("Compare results failed: ${header.ResourceLinkDescription}")
                     .handled(true)
@@ -55,7 +55,7 @@ public class CompareResultsRoute extends RouteBuilder {
                 .removeHeader("SrcList")
                 .removeHeader("TargetList")
                 .marshal().csv()
-                .setHeader("ResourceLinkDescription").simple("Completed ${header.ComparisonDescription}.")
+                .setHeader("ResourceLinkDescription").simple("Completed ${header.ComparisonDescription}")
                 .log("Compare results succeeded: ${header.ResourceLinkDescription}")
                 .toD("${header.Destination}");
     }

--- a/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendEmailRoute.java
+++ b/src/main/java/uk/gov/companieshouse/reconciliation/function/email/SendEmailRoute.java
@@ -32,7 +32,7 @@ public class SendEmailRoute extends RouteBuilder {
                         .enrich("direct:s3-publisher", (prev, curr) -> {
                             if(curr.getIn().getHeader("Failed", boolean.class)) {
                                 prev.getIn().setHeader("ResourceLinkReference", null);
-                                prev.getIn().setHeader("ResourceLinkDescription", String.format("Failed to upload results for %s to S3.", curr.getIn().getHeader("ComparisonDescription", String.class)));
+                                prev.getIn().setHeader("ResourceLinkDescription", String.format("Failed to upload results for %s to S3", curr.getIn().getHeader("ComparisonDescription", String.class)));
                             } else {
                                 prev.getIn().setHeader("ResourceLinkReference", curr.getIn().getHeader("ResourceLinkReference"));
                             }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_collection/CompareCollectionRouteTest.java
@@ -77,7 +77,7 @@ public class CompareCollectionRouteTest {
     void testCompareCollectionSetsDescriptionToFailureMessageIfComparisonFailsDueToSrc() throws InterruptedException {
         mockFruitTreeEndpoint.returnReplyHeader("Failed", ExpressionBuilder.constantExpression(true));
         mockFruitBasketEndpoint.expectedMessageCount(0);
-        mockCompareResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison.");
+        mockCompareResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison");
         producerTemplate.send(createExchange());
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -86,7 +86,7 @@ public class CompareCollectionRouteTest {
     void testCompareCollectionSetsDescriptionToFailureMessageIfComparisonFailsDueToTarget() throws InterruptedException {
         mockFruitTreeEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(new ResourceList(Arrays.asList("apple", null), "Fruit Tree")));
         mockFruitBasketEndpoint.returnReplyHeader("Failed", ExpressionBuilder.constantExpression(true));
-        mockCompareResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison.");
+        mockCompareResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison");
         producerTemplate.send(createExchange());
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_count/CompareCountRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_count/CompareCountRouteTest.java
@@ -52,7 +52,7 @@ public class CompareCountRouteTest {
     void testEndpointAIsGreaterThanEndpointB() throws InterruptedException {
         mockCorporateBodyCountEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(BigDecimal.valueOf(15)));
         mockCompanyProfileCountEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(10L));
-        mockResult.expectedHeaderReceived("ResourceLinkDescription", "A has 5 more things than B.");
+        mockResult.expectedHeaderReceived("ResourceLinkDescription", "A has 5 more things than B");
         template.sendBodyAndHeaders(0, createHeaders());
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -61,7 +61,7 @@ public class CompareCountRouteTest {
     void testEndpointBIsGreaterThanEndpointA() throws InterruptedException {
         mockCorporateBodyCountEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(BigDecimal.valueOf(10)));
         mockCompanyProfileCountEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(20L));
-        mockResult.expectedHeaderReceived("ResourceLinkDescription", "B has 10 more things than A.");
+        mockResult.expectedHeaderReceived("ResourceLinkDescription", "B has 10 more things than A");
         template.sendBodyAndHeaders(0, createHeaders());
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -70,7 +70,7 @@ public class CompareCountRouteTest {
     void testEndpointsAreTheSame() throws InterruptedException {
         mockCorporateBodyCountEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(BigDecimal.valueOf(10)));
         mockCompanyProfileCountEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(10));
-        mockResult.expectedHeaderReceived("ResourceLinkDescription", "A and B contain the same number of things.");
+        mockResult.expectedHeaderReceived("ResourceLinkDescription", "A and B contain the same number of things");
         template.sendBodyAndHeaders(0, createHeaders());
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -80,7 +80,7 @@ public class CompareCountRouteTest {
         mockCorporateBodyCountEndpoint.whenAnyExchangeReceived(exchange -> {
             throw new SQLException("Failed");
         });
-        mockResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison.");
+        mockResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison");
         template.sendBodyAndHeaders(0, createHeaders());
         MockEndpoint.assertIsSatisfied(context);
     }
@@ -90,7 +90,7 @@ public class CompareCountRouteTest {
         mockCorporateBodyCountEndpoint.whenAnyExchangeReceived(exchange -> {
             throw new MongoException("Failed");
         });
-        mockResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison.");
+        mockResult.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison");
         template.sendBodyAndHeaders(0, createHeaders());
         MockEndpoint.assertIsSatisfied(context);
     }

--- a/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRouteTest.java
+++ b/src/test/java/uk/gov/companieshouse/reconciliation/function/compare_results/CompareResultsRouteTest.java
@@ -70,7 +70,7 @@ public class CompareResultsRouteTest {
         targetEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(targetResults));
         output.allMessages().body().isEqualTo(
                 "Company Number,MongoDB - Company Profile,Primary Search Index\r\n12345678,ACME LTD,ACME LIMITED\r\n");
-        output.expectedHeaderReceived("ResourceLinkDescription", "Completed comparison.");
+        output.expectedHeaderReceived("ResourceLinkDescription", "Completed comparison");
         transformer.expectedHeaderReceived("SrcList", srcResults);
         transformer.expectedHeaderReceived("SrcDescription", "MongoDB - Company Profile");
         transformer.expectedHeaderReceived("TargetList", targetResults);
@@ -106,7 +106,7 @@ public class CompareResultsRouteTest {
     void testSetLinkDescriptionToFailureMessageIfComparisonSourceFails() throws InterruptedException {
         //given
         srcEndpoint.returnReplyHeader("Failed", ExpressionBuilder.constantExpression(true));
-        output.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison.");
+        output.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison");
 
         //when
         producerTemplate.sendBodyAndHeaders(0, createHeaders());
@@ -123,7 +123,7 @@ public class CompareResultsRouteTest {
                 new ResultModel("ABCD1234", "UNLIMITED LTD")));
         srcEndpoint.returnReplyBody(ExpressionBuilder.constantExpression(srcResults));
         targetEndpoint.returnReplyHeader("Failed", ExpressionBuilder.constantExpression(true));
-        output.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison.");
+        output.expectedHeaderReceived("ResourceLinkDescription", "Failed to perform comparison");
 
         //when
         producerTemplate.sendBodyAndHeaders(0, createHeaders());


### PR DESCRIPTION
* Fix issue causing email to be malformed if line of text is 76
  characters long and proceeded by a full stop.

Resolves
[BI-8872](https://companieshouse.atlassian.net/browse/BI-8872)