### PR TITLE
test create scheduler for testing

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -29,14 +29,13 @@ data "aws_ecs_cluster" "ecs_cluster" {
   cluster_name = "${local.name_prefix}-cluster"
 }
 
-data "aws_iam_role" "eventbridge_role" {
-  name = "${local.name_prefix}-eventbridge-scheduler-role"
-}
-
-data "aws_iam_role" "eventbridge_scheduler_role_arn" {
+data "aws_iam_role" "ecs_cluster_iam_role" {
   name = "${local.name_prefix}-ecs-task-execution-role"
 }
 
+data "aws_iam_role" "eventbridge_role" {
+  name = "${local.name_prefix}-eventbridge-scheduler-role"
+}
 
 # retrieve all secrets for this stack using the stack path
 data "aws_ssm_parameters_by_path" "secrets" {

--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -29,7 +29,11 @@ data "aws_ecs_cluster" "ecs_cluster" {
   cluster_name = "${local.name_prefix}-cluster"
 }
 
-data "aws_iam_role" "ecs_cluster_iam_role" {
+data "aws_iam_role" "eventbridge_role" {
+  name = "${local.name_prefix}-eventbridge-scheduler-role"
+}
+
+data "aws_iam_role" "eventbridge_scheduler_role_arn" {
   name = "${local.name_prefix}-ecs-task-execution-role"
 }
 

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -70,7 +70,7 @@ module "ecs-service" {
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids
   read_only_root_filesystem          = false
-
+  enable_scheduler                   = true
 
   # Service environment variable and secret configs
   task_environment          = local.task_environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -71,7 +71,10 @@ module "ecs-service" {
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids
   read_only_root_filesystem          = false
-  enable_scheduler                   = true
+
+  # # Scheduler configuration
+  # enable_scheduler                   = true
+  # scheduler_cron                     = "cron(0/15 6-17 ? * MON-FRI *)"
 
   # Service environment variable and secret configs
   task_environment          = local.task_environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -38,6 +38,7 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
+  eventbridge_scheduler_role_arn = data.aws_iam_role.eventbridge_role.arn
   batch_service           = true
   
 

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -72,9 +72,11 @@ module "ecs-service" {
   fargate_subnets                    = local.application_subnet_ids
   read_only_root_filesystem          = false
 
-  # # Scheduler configuration
-  # enable_scheduler                   = true
-  # scheduler_cron                     = "cron(0/15 6-17 ? * MON-FRI *)"
+  # Scheduler configuration
+  enable_scheduler                   = var.enable_scheduler
+  scheduler_cron                     = var.scheduler_cron
+  
+  # "cron(0/15 6-17 ? * MON-FRI *)"
 
   # Service environment variable and secret configs
   task_environment          = local.task_environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=feature/JU-954-fix-healthcheck"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=feature/JU-954-add-scheduler"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment
@@ -28,7 +28,7 @@ module "secrets" {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=feature/JU-954-fix-healthcheck"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=feature/JU-954-add-scheduler"
 
 
   # Environmental configuration
@@ -42,8 +42,8 @@ module "ecs-service" {
   
 
   # ECS Task container health check
-  use_task_container_healthcheck    = true
-  healthcheck_command               = "pgrep -q java; [[ $? -ne 1 ]] || exit 1"
+  # use_task_container_healthcheck    = false
+  # healthcheck_command               = "pgrep -q java; [[ $? -ne 1 ]] || exit 1"
   healthcheck_path                  = local.healthcheck_path
   healthcheck_matcher               = local.healthcheck_matcher
   health_check_grace_period_seconds = 240

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -5,12 +5,6 @@ aws_profile = "development-eu-west-2"
 use_set_environment_files = true
 
 
-# Scheduled scaling of tasks
-service_autoscale_enabled  = true
-service_scaleup_schedule   = "0,15,30,45 6-17 ? * MON-FRI *"
-service_scaledown_schedule = "58,13,28,43 6-17 ? * MON-FRI *"
-
-# scaling configs
-desired_task_count = 0
-max_task_count     = 1
-min_task_count     = 0
+# Scheduler configuration
+enable_scheduler       = true
+scheduler_cron         = "cron(0/15 6-17 ? * MON-FRI *)"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -5,6 +5,6 @@ aws_profile = "development-eu-west-2"
 use_set_environment_files = true
 
 
-# # Scheduler configuration
-# enable_scheduler       = true
-# scheduler_cron         = "cron(0/15 6-17 ? * MON-FRI *)"
+# Scheduler configuration
+enable_scheduler       = true
+scheduler_cron         = "cron(0/15 6-17 ? * MON-FRI *)"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -5,6 +5,6 @@ aws_profile = "development-eu-west-2"
 use_set_environment_files = true
 
 
-# Scheduler configuration
-enable_scheduler       = true
-scheduler_cron         = "cron(0/15 6-17 ? * MON-FRI *)"
+# # Scheduler configuration
+# enable_scheduler       = true
+# scheduler_cron         = "cron(0/15 6-17 ? * MON-FRI *)"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -115,3 +115,21 @@ variable "data_reconciliation_version" {
   type        = string
   description = "The version of the data-reconciliation container to run."
 }
+
+
+
+# ------------------------------------------------------------------------------
+# Scheduler variables
+# ------------------------------------------------------------------------------
+
+variable "enable_scheduler" {
+  description = "Whether to enable the EventBridge scheduler for the ECS service"
+  type        = bool
+  default     = false
+}
+
+variable "scheduler_cron" {
+  description = "Cron expression for the scheduler"
+  type        = string
+  default     = "" 
+}


### PR DESCRIPTION
PR to create scheduler for testing also remove autoscaling previously created to enable better testing

Note: 
i am testing on my branch and will revert once completed. 

excerpt of tfrunner 
===============
 module.ecs-service.aws_ecs_service.ecs-service will be updated in-place
  ~ resource "aws_ecs_service" "ecs-service" {
        id                                 = "arn:aws:ecs:eu-west-2:169942020521:service/data-reconciliation-service-cidev-cluster/cidev-data-reconciliation"
        name                               = "cidev-data-reconciliation"
        tags                               = {
            "ECSClusterName"     = "data-reconciliation-service-cidev-cluster"
            "Environment"        = "cidev"
            "ManagedByTerraform" = "true"
            "ServiceName"        = "data-reconciliation"
            "UseFargate"         = "true"
        }
      ~ task_definition                    = "arn:aws:ecs:eu-west-2:169942020521:task-definition/cidev-data-reconciliation:36" -> (known after apply)
        # (15 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }

 module.ecs-service.aws_ecs_task_definition.ecs-task-definition must be replaced
-/+ resource "aws_ecs_task_definition" "ecs-task-definition" {
      ~ arn                      = "arn:aws:ecs:eu-west-2:169942020521:task-definition/cidev-data-reconciliation:36" -> (known after apply)
      ~ container_definitions    = (sensitive value) # forces replacement
      ~ id                       = "cidev-data-reconciliation" -> (known after apply)
      - ipc_mode                 = "" -> null
      - pid_mode                 = "" -> null
      ~ revision                 = 36 -> (known after apply)
        tags                     = {
            "ECSClusterName"     = "data-reconciliation-service-cidev-cluster"
            "Environment"        = "cidev"
            "ManagedByTerraform" = "true"
            "ServiceName"        = "data-reconciliation"
            "UseFargate"         = "true"
        }
      - task_role_arn            = "" -> null
        # (8 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  module.ecs-service.aws_scheduler_schedule.ecs_service_scheduler[0] will be created
  + resource "aws_scheduler_schedule" "ecs_service_scheduler" {
      + arn                          = (known after apply)
      + description                  = "Scheduler for ECS service"
      + group_name                   = (known after apply)
      + id                           = (known after apply)
      + name                         = "data-reconciliation-service-cidev-ecs-scheduler"
      + name_prefix                  = (known after apply)
      + schedule_expression          = "cron(0/15 6-17 ? * MON-FRI *)"
      + schedule_expression_timezone = "UTC"
      + state                        = "ENABLED"

      + flexible_time_window {
          + mode = "OFF"
        }

      + target {
          + arn      = "arn:aws:scheduler:::aws-sdk:ecs:updateService"
          + input    = jsonencode(
                {
                  + cluster      = "arn:aws:ecs:eu-west-2:169942020521:cluster/data-reconciliation-service-cidev-cluster"
                  + desiredCount = 1
                  + service      = "data-reconciliation"
                }
            )
          + role_arn = "arn:aws:iam::169942020521:role/data-reconciliation-service-cidev-eventbridge-scheduler-role"
        }
    }

Plan: 2 to add, 1 to change, 3 to destroy.