### PR TITLE
set-read_only_root_file_System-to-true

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -73,7 +73,6 @@ module "ecs-service" {
   use_capacity_provider              = var.use_capacity_provider
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids
-  read_only_root_filesystem          = false
 
   # Scheduler configuration
   enable_eventbridge_scheduler                   = var.enable_eventbridge_scheduler


### PR DESCRIPTION
setting the root file system to read only as part of aws security remediation